### PR TITLE
🧹 [code health improvement] Fix Unsafe Use of GitHub Context in Shell Scripts

### DIFF
--- a/.github/workflows/0-start-exercise.yml
+++ b/.github/workflows/0-start-exercise.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Create comment - add step content
         run: |
           gh issue comment "$ISSUE_URL" \
-            --body-file ${{ env.STEP_1_FILE }}
+            --body-file "$STEP_1_FILE"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/1-create-a-branch.yml
+++ b/.github/workflows/1-create-a-branch.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Create comment - add step content
         run: |
           gh issue comment "$ISSUE_URL" \
-            --body-file ${{ env.STEP_2_FILE }}
+            --body-file "$STEP_2_FILE"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/2-commit-a-file.yml
+++ b/.github/workflows/2-commit-a-file.yml
@@ -95,10 +95,11 @@ jobs:
       - name: Update comment - step finished
         run: |
           gh issue comment "$ISSUE_URL" \
-            --body "${{ steps.build-message-step-finish.outputs.updated-text }}" \
+            --body "$FINISHED_MESSAGE" \
             --edit-last
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FINISHED_MESSAGE: ${{ steps.build-message-step-finish.outputs.updated-text }}
 
   post_next_step_content:
     name: Post next step content
@@ -121,7 +122,7 @@ jobs:
       - name: Create comment - add step content
         run: |
           gh issue comment "$ISSUE_URL" \
-            --body-file ${{ env.STEP_3_FILE }}
+            --body-file "$STEP_3_FILE"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/3-open-a-pull-request.yml
+++ b/.github/workflows/3-open-a-pull-request.yml
@@ -60,6 +60,9 @@ jobs:
 
       - name: Check user work
         id: check-user-work
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           # Checks to perform
           checks='{
@@ -76,13 +79,13 @@ jobs:
           }'
 
           # Check pull request title
-          if [ "${{ github.event.pull_request.title }}" != "Add my first file" ]; then
+          if [ "$PR_TITLE" != "Add my first file" ]; then
             checks=$(echo $checks | jq '.pr_title.passed = false')
             checks=$(echo $checks | jq '.pr_title.message = "Incorrect title"')
           fi
 
           # Check if a pull request description exists
-          if [ "${{ github.event.pull_request.body }}" == "" ]; then
+          if [ "$PR_BODY" == "" ]; then
             checks=$(echo $checks | jq '.pr_description.passed = false')
             checks=$(echo $checks | jq '.pr_description.message = "Empty pull request description"')
           fi
@@ -119,10 +122,11 @@ jobs:
       - name: Create comment - step results
         run: |
           gh issue comment "$ISSUE_URL" \
-            --body "${{ steps.build-message-step-results.outputs.updated-text }}" \
+            --body "$RESULTS_MESSAGE" \
             --edit-last
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RESULTS_MESSAGE: ${{ steps.build-message-step-results.outputs.updated-text }}
 
       - name: Fail job if not all checks passed
         if: steps.check-user-work.outputs.passed == 'false'
@@ -139,9 +143,10 @@ jobs:
       - name: Update comment - step finished
         run: |
           gh issue comment "$ISSUE_URL" \
-            --body "${{ steps.build-message-step-finish.outputs.updated-text }}"
+            --body "$FINISHED_MESSAGE"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FINISHED_MESSAGE: ${{ steps.build-message-step-finish.outputs.updated-text }}
 
   post_step_4_content:
     name: Post step 4 content
@@ -164,7 +169,7 @@ jobs:
       - name: Create comment - add step content
         run: |
           gh issue comment "$ISSUE_URL" \
-            --body-file ${{ env.STEP_4_FILE }}
+            --body-file "$STEP_4_FILE"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/4-merge-your-pull-request.yml
+++ b/.github/workflows/4-merge-your-pull-request.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Create comment - add review content
         run: |
           gh issue comment "$ISSUE_URL" \
-            --body-file ${{ env.REVIEW_FILE }}
+            --body-file "$REVIEW_FILE"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -91,7 +91,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Disable current workflow
-        run: gh workflow disable "${{github.workflow}}"
+        run: gh workflow disable "$WORKFLOW_NAME"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_NAME: ${{ github.workflow }}
 


### PR DESCRIPTION
This PR addresses a code health and security issue where GitHub context values (like pull request titles and descriptions) were directly interpolated into shell scripts within GitHub Actions workflows. This pattern is vulnerable to script injection and can cause syntax errors with unexpected input.

The fix involves:
1. Mapping `github.event.pull_request.title` and `github.event.pull_request.body` to environment variables (`PR_TITLE`, `PR_BODY`) within the relevant steps.
2. Updating shell scripts to use these environment variables (e.g., `"$PR_TITLE"`) instead of `${{ ... }}` interpolation.
3. Consistently applying this pattern to step outputs and other GitHub context values used in `run:` blocks across all workflow files (`0-start-exercise.yml` through `4-merge-your-pull-request.yml`).

These changes improve the security and maintainability of the codebase without altering the behavior of the workflows.

---
*PR created automatically by Jules for task [5180260516985825681](https://jules.google.com/task/5180260516985825681) started by @lostlight530*