### PR TITLE
🧹 [code health] Standardize workflow disabling/enabling method

### DIFF
--- a/.github/workflows/0-start-exercise.yml
+++ b/.github/workflows/0-start-exercise.yml
@@ -59,6 +59,7 @@ jobs:
 
       - name: Disable current workflow and enable next one
         run: |
+          gh workflow disable "${{ github.workflow }}"
           gh workflow enable "Step 1"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/1-create-a-branch.yml
+++ b/.github/workflows/1-create-a-branch.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Disable current workflow and enable next one
         run: |
-          gh workflow disable "1-create-a-branch.yml"
-          gh workflow enable "2-commit-a-file.yml"
+          gh workflow disable "${{ github.workflow }}"
+          gh workflow enable "Step 2"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/2-commit-a-file.yml
+++ b/.github/workflows/2-commit-a-file.yml
@@ -134,7 +134,7 @@ jobs:
 
       - name: Disable current workflow and enable next one
         run: |
-          gh workflow disable "2-commit-a-file.yml"
-          gh workflow enable "3-open-a-pull-request.yml"
+          gh workflow disable "${{ github.workflow }}"
+          gh workflow enable "Step 3"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/3-open-a-pull-request.yml
+++ b/.github/workflows/3-open-a-pull-request.yml
@@ -177,7 +177,7 @@ jobs:
 
       - name: Disable current workflow and enable next one
         run: |
-          gh workflow disable "3-open-a-pull-request.yml"
-          gh workflow enable "4-merge-your-pull-request.yml"
+          gh workflow disable "${{ github.workflow }}"
+          gh workflow enable "Step 4"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/4-merge-your-pull-request.yml
+++ b/.github/workflows/4-merge-your-pull-request.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Disable current workflow
-        run: gh workflow disable "${{github.workflow}}"
+        run: gh workflow disable "${{ github.workflow }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
- 统一了所有 GitHub 工作流中禁用当前工作流和启用下一个工作流的方式。
- 将硬编码的文件名（如 `1-create-a-branch.yml`）替换为动态的 `${{ github.workflow }}`。
- 将启用下一个工作流的方式统一为使用名称前缀（如 `Step 2`），以符合 `0-start-exercise.yml` 的现有风格。

💡 **Why:** How this improves maintainability
- **鲁棒性**：使用 `${{ github.workflow }}` 可以避免因文件名更改而导致工作流逻辑失效。
- **一致性**：全库统一的操作模式降低了维护成本和认知负担。
- **可靠性**：为 `0-start-exercise.yml` 添加了自禁用逻辑，确保其在触发后正确停止，与其他步骤保持一致。

✅ **Verification:** How you confirmed the change is safe
- 进行了静态代码检查，确保 YAML 语法正确。
- 通过了代码审查，确认逻辑符合 GitHub Actions 的最佳实践。
- 验证了所有变量引用（如 `GH_TOKEN`）在各步骤中均已正确配置。

✨ **Result:** The improvement achieved
- 工作流代码更加简洁、健壮，且符合全库统一的标准。

---
*PR created automatically by Jules for task [4204254114997057484](https://jules.google.com/task/4204254114997057484) started by @lostlight530*