### PR TITLE
fix(portal): resolve 404 for memorial link

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,7 +265,7 @@
 
     <div class="flex justify-center space-x-6">
       <a href="https://github.com/lostlight530" class="text-gray-500 hover:text-white transition-colors">GitHub</a>
-      <a href="./docs/archaeology/MEMORIAL.md" class="text-gray-500 hover:text-white transition-colors">Memorial</a>
+      <a href="./docs/archaeology/legacy_traces/MEMORIAL.md" class="text-gray-500 hover:text-white transition-colors">Memorial</a>
     </div>
   </footer>
 


### PR DESCRIPTION
This PR updates the "Memorial" link in the `index.html` footer to correctly point to the archived location (`./docs/archaeology/legacy_traces/MEMORIAL.md`) instead of the non-existent `./docs/archaeology/MEMORIAL.md`. This resolves the 404 File Not Found issue reported by the user while adhering to the site's static structure.

---
*PR created automatically by Jules for task [5199057338977593793](https://jules.google.com/task/5199057338977593793) started by @lostlight530*