### PR TITLE
[W1] CORTEX Harvester 2026-06-08

### DIFF
--- a/docs/brain/inputs/ModelEngine-Group_nexent_v2.2.0.md
+++ b/docs/brain/inputs/ModelEngine-Group_nexent_v2.2.0.md
@@ -1,0 +1,109 @@
+# ℹ️ Intel Report: ModelEngine-Group/nexent
+## 🎯 监控目标 (Target)
+> ModelEngine-Group/nexent
+
+## 🚀 新版本发布 (New Release)
+> Version: v2.2.0
+> Date: 2026-06-08T04:59:03.171080
+
+## 💡 项目洞察 (Insight)
+> **Architect's Analysis**: 🏷️ Edge-Ready 🔗 Agent-Protocol
+
+## 🛡️ 信任评分 (Trust Score)
+> Score: 100/100
+
+## 🔨 最近提交 (Recent Commits)
+*Summary from release notes:*
+
+# 🚀 Nexent：开源智能体平台 / Nexent: Open Source Intelligent Agent Platform
+
+我们很高兴地宣布Nexent v2.2.0 正式发布！🎉
+
+Nexent 是一个开源智能体平台，能够将流程的自然语言转化为完整的多模态智能体 —— 无需编排，无需复杂拖拉拽。基于 MCP 工具生态，Nexent 提供强大的模型集成、数据处理、知识库管理、零代码智能体开发能力。我们的目标很简单：将数据、模型和工具整合到一个智能中心中，使日常工作流程更智能、更互联。
+
+We are excited to announce that Nexent v2.2.0 is released! 🎉
+Nexent is an open-source agent platform that turns process-level natural language into complete multimodal agents — no diagrams, no wiring. Built on the MCP tool ecosystem, Nexent provides model integration, data processing, knowledge-base management, and zero-code agent development. Our goal is simple: to bring data, models, and tools together in one smart hub, making daily workflows smarter and more connected.
+
+---
+## 新功能 / New Features
+- 新增或增强了 Agent 生成模板管理、A2A 相关协作能力、Vision-Language 识别与音频理解工具。 / Added or improved agent generation template management, A2A collaboration capabilities, and vision-language plus audio understanding tools.
+- 支持用户配置模型并发限制和超时时间，提升推理资源控制能力。 / Added user-configurable model concurrency limits and timeout settings to improve inference resource control.
+- 增强上下文管理，并为 Agent 上下文模块增加基准测试。 / Improved context management and added benchmarks for the agent context module.
+- 新增技能、MCP 服务、自定义 header、工具执行日志等平台扩展能力。 / Added platform extensibility for skills, MCP services, custom headers, and tool execution logging.
+- 新增资源权限与角色相关能力，例如 `ASSET_OWNER` 角色与资源可见性控制。 / Added resource access features such as the `ASSET_OWNER` role and resource visibility enforcement.
+- 扩展多模态与文档能力，包括 office/PDF 图片抽取与检索、TTS 语音模型支持等。 / Expanded multimodal and document capabilities, including image extraction/retrieval for office/PDF files and TTS model support.
+## Bug 修复 / Bug Fixes
+- 修复外部协作 Agent 保存、权限控制、模型添加、Agent Prompt 生成等问题。 / Fixed external collaboration agent saving, permission control, model addition, and agent prompt generation issues.
+- 修复 MCP 集成相关问题，包括代理环境变量干扰与工具调用异常。 / Fixed MCP integration issues, including proxy environment variable interference and tool call failures.
+- 修复知识库与会话历史相关问题，例如记录缺少 `embedding_model_id`、会话历史未正确保存。 / Fixed knowledge base and conversation history issues, such as missing `embedding_model_id` and incorrect history persistence.
+- 修复调试模式中错误信息不充分、模型输出历史未包含、`iData` 工具调用失败等问题。 / Fixed insufficient error details in debug mode, missing model output history, and `iData` tool call failures.
+- 修复登录/注册、技能/工具按钮状态、无网络场景下 VLM 添加、图片预览旋转等体验问题。 / Fixed UX issues around login/register flows, skill/tool button states, VLM addition without network access, and image preview rotation.
+- 修复部署持久化、Docker SQL 重复、监控环境变量同步等问题。 / Fixed deployment persistence, Docker SQL duplication, and monitoring environment variable sync issues.
+## 文档与部署变化 / Docs & Deployment Changes
+- 新增 SQL tools 文档、MCP 服务 API 文档，并更新 skill 相关说明。 / Added SQL tools documentation, MCP service API documentation, and updated skill-related docs.
+- 增加离线部署包构建流程，并优化部署脚本与 Helm 指南。 / Added offline deployment package build flow and improved deployment scripts and Helm guidance.
+- 增加引导用户 star 仓库的文案与文档提示。 / Added prompts and documentation nudges encouraging users to star the repository.
+
+## What's Changed
+* Fix external collaboration agent saving and related bugs by @Dallas98 in https://github.com/ModelEngine-Group/nexent/pull/2993
+* Optimize prompt by @2h0u4n in https://github.com/ModelEngine-Group/nexent/pull/2924
+* 📃 Add sql tools document by @WMC001 in https://github.com/ModelEngine-Group/nexent/pull/3005
+* 🐛 Bugfix: Avoid directly modifying files in the runtime environment using code. #3006 by @WMC001 in https://github.com/ModelEngine-Group/nexent/pull/3007
+* 🐛 Bugfix: Auto-clean account when exists in Supabase but not in postgresql by @xuyaqist in https://github.com/ModelEngine-Group/nexent/pull/3002
+* Chore: Add workflow and script for offline deployment package build by @Dallas98 in https://github.com/ModelEngine-Group/nexent/pull/3010
+* Chore: Add workflow and script for offline deployment package build by @Dallas98 in https://github.com/ModelEngine-Group/nexent/pull/3011
+* feat: add prompt template management for agent generation by @2h0u4n in https://github.com/ModelEngine-Group/nexent/pull/2925
+* Refine and internationalize OAuth account completion flow by @hhhhsc701 in https://github.com/ModelEngine-Group/nexent/pull/2984
+* Enhance monitoring with OpenTelemetry, Grafana, and new providers by @hhhhsc701 in https://github.com/ModelEngine-Group/nexent/pull/2969
+* ✨ Feat: support user to configurate model concurrency limit and timeout seconds by @xuyaqist in https://github.com/ModelEngine-Group/nexent/pull/2943
+* ✨ Support modifying passward #2809 by @WMC001 in https://github.com/ModelEngine-Group/nexent/pull/3016
+* ♻️ Mcp Tools Management Page Development by @HelloWorldGitHub114 in https://github.com/ModelEngine-Group/nexent/pull/2771
+* ♻️ Performance optimization of the knowledge base file list query interface by @WMC001 in https://github.com/ModelEngine-Group/nexent/pull/3025
+* ✨ Skill ability enhancement and bug fix by @Jasonxia007 in https://github.com/ModelEngine-Group/nexent/pull/3017
+* 🐛 Fixes the model addition issue in ModelEngine. by @YehongPan in https://github.com/ModelEngine-Group/nexent/pull/3026
+* Feat: support user to add and use tts model by @wadecrack in https://github.com/ModelEngine-Group/nexent/pull/2959
+* 🐛 Bugfix: Cannot generate agent prompt by @Jasonxia007 in https://github.com/ModelEngine-Group/nexent/pull/3028
+* ♻️ Refactor: Optimize agent page layout & refactor agent generate page by @xuyaqist in https://github.com/ModelEngine-Group/nexent/pull/3020
+* Optimize deployment scripts and improve Helm chart instructions by @hhhhsc701 in https://github.com/ModelEngine-Group/nexent/pull/3029
+* ♻️ Add v2.2.0 shell script to update the directory of skills by @Jasonxia007 in https://github.com/ModelEngine-Group/nexent/pull/3035
+* Feat: Add vision-language model classification and audio understanding tools by @827dsl in https://github.com/ModelEngine-Group/nexent/pull/3001
+* feat: Support image extraction & retrieval for office/PDF documents by @yzAiden in https://github.com/ModelEngine-Group/nexent/pull/2720
+* feat: support multi-turn compare sessions by @2h0u4n in https://github.com/ModelEngine-Group/nexent/pull/3012
+* ♻️ Improvement: Supports adding custom headers when adding MCP services. by @YehongPan in https://github.com/ModelEngine-Group/nexent/pull/3036
+* Fix markdown table code block diaplay eccentrically by @MoeexT in https://github.com/ModelEngine-Group/nexent/pull/2992
+* Support adding models individually and Fix audio tools by @827dsl in https://github.com/ModelEngine-Group/nexent/pull/3049
+* 🐛 Bugfix: Fix the issue with permission control for released agents. by @YehongPan in https://github.com/ModelEngine-Group/nexent/pull/3052
+* :bug: Add detail error message in debug mode by @MoeexT in https://github.com/ModelEngine-Group/nexent/pull/2977
+* 🐛 Bugfix: Fix iData tool call error. by @YehongPan in https://github.com/ModelEngine-Group/nexent/pull/3054
+* ✨ Feat: Context management refactoring. Add benchmark for agent context module. by @JasonW404 in https://github.com/ModelEngine-Group/nexent/pull/3039
+* ✨ feat: increase agent max_steps default to 15 and widen bounds to 30 by @JasonW404 in https://github.com/ModelEngine-Group/nexent/pull/3057
+* 🐛 Bugfix: Fix no password check when creating tenant admin by @WMC001 in https://github.com/ModelEngine-Group/nexent/pull/3061
+* refactor: remove unnecessary interactions by @yzAiden in https://github.com/ModelEngine-Group/nexent/pull/3065
+* Add Link App OAuth provider support and update configurations by @hhhhsc701 in https://github.com/ModelEngine-Group/nexent/pull/3068
+* ✨ Feat: add ASSET_OWNER role, enforce asset visibility, and refine no… by @Lifeng-Chen in https://github.com/ModelEngine-Group/nexent/pull/3042
+* knowledge_base_search工具参数中添加index_names输入参数 by @yzAiden in https://github.com/ModelEngine-Group/nexent/pull/3078
+* 🐛 Bugfix: Disable tool and skill selection when user is not in edit mode by @xuyaqist in https://github.com/ModelEngine-Group/nexent/pull/3064
+* Bugfix: when user login or register, do not open session expire modal by @xuyaqist in https://github.com/ModelEngine-Group/nexent/pull/3082
+* ♻️ Add log of tool execution by @WMC001 in https://github.com/ModelEngine-Group/nexent/pull/3081
+* ♻️ Docker sql duplicate fix by @Jasonxia007 in https://github.com/ModelEngine-Group/nexent/pull/3080
+* Style: Align agent dropdown list width with parent component by @xuyaqist in https://github.com/ModelEngine-Group/nexent/pull/3113
+* feat(model): optimize model type labels and max token input by @Dallas98 in https://github.com/ModelEngine-Group/nexent/pull/3117
+* 🐛 Bugfix: Disable skill buttons when page is not in edit mode by @xuyaqist in https://github.com/ModelEngine-Group/nexent/pull/3120
+* Fix deployment persistence and sync monitoring environment variables by @hhhhsc701 in https://github.com/ModelEngine-Group/nexent/pull/3127
+* Add ASSET_OWNER role with OAuth registration and resource permissions  by @Lifeng-Chen in https://github.com/ModelEngine-Group/nexent/pull/3086
+* 🐛 Bugfix: Fix MCP integration by ignoring proxy environment variables by @xuyaqist in https://github.com/ModelEngine-Group/nexent/pull/3121
+* Add deployment script guidance for monitoring and OAuth by @hhhhsc701 in https://github.com/ModelEngine-Group/nexent/pull/3168
+* 🐛 Bugfix: Batch add dashscope embedding model failed to calculate embedding dimension by @Jasonxia007 in https://github.com/ModelEngine-Group/nexent/pull/3172
+* Bugfix: Store created_by when rolling back version by @xuyaqist in https://github.com/ModelEngine-Group/nexent/pull/3175
+* 📃 Add multimodal tools document by @WMC001 in https://github.com/ModelEngine-Group/nexent/pull/3177
+* 🐛 Bugfix: Constraints and Examples falsely generated when user didn't choose any tools or subagents by @Jasonxia007 in https://github.com/ModelEngine-Group/nexent/pull/3179
+* Fix: Update DashScope provider for realtime WebSocket and translations by @Dallas98 in https://github.com/ModelEngine-Group/nexent/pull/3178
+* add_epub_dependency by @yzAiden in https://github.com/ModelEngine-Group/nexent/pull/3176
+* Release v2.2.0  by @DongJiBao2001 in https://github.com/ModelEngine-Group/nexent/pull/3183
+
+## New Contributors
+* @HelloWorldGitHub114 made their first contribution in https://github.com/ModelEngine-Group/nexent/pull/2771
+* @827dsl made their first contribution in https://github.com/ModelEngine-Group/nexent/pull/3001
+* @Lifeng-Chen made their first contribution in https://github.com/ModelEngine-Group/nexent/pull/3042
+
+**Full Changelog**: https://github.com/ModelEngine-Group/nexent/compare/v2.1.1...v2.2.0

--- a/docs/brain/inputs/google-ai-edge_mediapipe_v0.10.35.md
+++ b/docs/brain/inputs/google-ai-edge_mediapipe_v0.10.35.md
@@ -1,0 +1,56 @@
+# ℹ️ Intel Report: google-ai-edge/mediapipe
+## 🎯 监控目标 (Target)
+> google-ai-edge/mediapipe
+
+## 🚀 新版本发布 (New Release)
+> Version: v0.10.35
+> Date: 2026-06-08T04:59:03.322400
+
+## 💡 项目洞察 (Insight)
+> **Architect's Analysis**: 🏷️ Edge-Ready
+
+## 🛡️ 信任评分 (Trust Score)
+> Score: 90/100
+
+## 🔨 最近提交 (Recent Commits)
+*Summary from release notes:*
+
+### Framework and core calculator improvements
+- Add histogram information to Tensor::DebugString.
+- Bump MediaPipe version to 0.10.35.
+- Add missing GL memory barrier in TensorsToSegmentationGlBufferConverter.
+- Migrate FromImageCalculator to MediaPipe API3 and add test.
+- Add api3::Packet::Share function.
+- Remove util/analytics references from GitHub build
+- Migrate ToImageCalculator to MediaPipe API3 and add tests.
+- Fix -Wthread-safety-analysis warning.
+- Allow MP Task files to be use in Vite's workers
+- Add save-png-by-path test util function.
+- Feat: Add configurable policy for handling empty landmarks in smoothing calculators
+- #mediapipe Make GPU service optional in ImageToTensorCalculator for iOS.
+- Add Host Platform Web and Host System iOS/Android to logging enums
+
+### MediaPipe Tasks update
+This section should highlight the changes that are done specifically for any platform and don't propagate to
+other platforms.
+
+#### Android
+- Allow users to use NPU acceleration with JIT compilation
+- Drop unnecessary `tasks/core` deps
+
+#### iOS
+- Change MP Tasks CocoaPods types to Framework
+
+#### Javascript
+- Remove references to "subgroups-f16"
+- Fix broken exports statement in package.json
+- Update MP Tasks GenAI README
+
+#### Python
+- Small fixes to blockwise int4 compression calculations in LLM converter
+- Allow for overriding apply_srq in LLM Converter
+- Small blockwise dequant helper for LLM Converter
+
+
+### MediaPipe Dependencies
+- Update Wasm file hashes and URLs in wasm_files.bzl

--- a/docs/brain/inputs/googleapis_python-genai_v2.8.0.md
+++ b/docs/brain/inputs/googleapis_python-genai_v2.8.0.md
@@ -1,0 +1,40 @@
+# ℹ️ Intel Report: googleapis/python-genai
+## 🎯 监控目标 (Target)
+> googleapis/python-genai
+
+## 🚀 新版本发布 (New Release)
+> Version: v2.8.0
+> Date: 2026-06-08T04:59:03.341935
+
+## 💡 项目洞察 (Insight)
+> **Architect's Analysis**: 🔗 Agent-Protocol
+
+## 🛡️ 信任评分 (Trust Score)
+> Score: 90/100
+
+## 🔨 最近提交 (Recent Commits)
+*Summary from release notes:*
+
+## [2.8.0](https://github.com/googleapis/python-genai/compare/v2.7.0...v2.8.0) (2026-06-03)
+
+
+### Features
+
+* Add Agent Platform MCP support to async generate_content ([e3be9af](https://github.com/googleapis/python-genai/commit/e3be9af3c21c9f8f625aecd890a5ee1f9993fb3d))
+* Add transcription language code. ([53ea3f6](https://github.com/googleapis/python-genai/commit/53ea3f689bf02ecbdbecf8a2a4aff77c48016eb9))
+* Add TranslationConfig for live translation. ([4775314](https://github.com/googleapis/python-genai/commit/47753147a30c10138f1a4e46c1c8e8069ae8e86d))
+* Support ReinforcementTuning in GenAI SDK including ValidateReward API method. ([e0854a6](https://github.com/googleapis/python-genai/commit/e0854a6d1f487435507d2cffd82ad133de8b931d))
+
+
+### Bug Fixes
+
+* Include all fields of a single tool ([7b1d498](https://github.com/googleapis/python-genai/commit/7b1d4982f4a61def33db8873feb1334416d4a0e4))
+
+
+### Documentation
+
+* A comment for field `enable_widget` in message `GoogleMaps` is changed ([74d81dd](https://github.com/googleapis/python-genai/commit/74d81dd2e3cfe9eb9350751cfbcb597fcd60a479))
+* A comment for field `google_maps_widget_context_token` in message `GroundingMetadata` is changed ([74d81dd](https://github.com/googleapis/python-genai/commit/74d81dd2e3cfe9eb9350751cfbcb597fcd60a479))
+* Remove `codegen_instructions.md` for simpler maintenance, Gemini API Skills should be the single source of truth ([bfa2a49](https://github.com/googleapis/python-genai/commit/bfa2a495e5c7e5acd232c46d3f84913f3a50522a))
+* Update README.md for model/SDK Changes and direct to Gemini API Skills ([47c1a13](https://github.com/googleapis/python-genai/commit/47c1a13e8475b3a2553e699f9ff0823d8757fa92))
+* Update the docs for 2.7 ([bbef98e](https://github.com/googleapis/python-genai/commit/bbef98e64ebf6e12a5ab1aba02302a28ca1faf4f))

--- a/docs/brain/inputs/huggingface_transformers_v5.10.2.md
+++ b/docs/brain/inputs/huggingface_transformers_v5.10.2.md
@@ -1,0 +1,21 @@
+# ℹ️ Intel Report: huggingface/transformers
+## 🎯 监控目标 (Target)
+> huggingface/transformers
+
+## 🚀 新版本发布 (New Release)
+> Version: v5.10.2
+> Date: 2026-06-08T04:59:03.155564
+
+## 🛡️ 信任评分 (Trust Score)
+> Score: 80/100
+
+## 🔨 最近提交 (Recent Commits)
+*Summary from release notes:*
+
+# Patch release v5.10.2
+There was a big bug in the model conversion of models related to clip, this affected models like sam3 and others. Please make sure to update :pray:
+
+* Fix conversion for clip models by @zucchini-nlp (#46406)
+
+
+**Full Changelog**: https://github.com/huggingface/transformers/compare/v5.10.1...v5.10.2

--- a/docs/brain/inputs/iflytek_astron-agent_v1.0.8.md
+++ b/docs/brain/inputs/iflytek_astron-agent_v1.0.8.md
@@ -1,0 +1,46 @@
+# ℹ️ Intel Report: iflytek/astron-agent
+## 🎯 监控目标 (Target)
+> iflytek/astron-agent
+
+## 🚀 新版本发布 (New Release)
+> Version: v1.0.8
+> Date: 2026-06-08T04:59:03.161675
+
+## 💡 项目洞察 (Insight)
+> **Architect's Analysis**: ⚠️ Breaking-Change 🔗 Agent-Protocol
+
+## 🛡️ 信任评分 (Trust Score)
+> Score: 100/100
+
+## 🔨 最近提交 (Recent Commits)
+*Summary from release notes:*
+
+This release focuses on production readiness across observability, credential management, workflow execution security, and deployment operations. It adds health checks, gateway authentication, platform account management, and several security hardening fixes.
+
+## Highlights
+
+### Core Capabilities
+- Added health check endpoints for core services, including Agent, Workflow, Knowledge, and Memory, making container orchestration, operational checks, and incident diagnosis easier (#1358).
+- Added platform account management to centralize platform-level runtime credentials and connect the Console, Knowledge, AI Tools, and plugin invocation paths (#1348).
+- Added Workflow gateway authentication based on tenant application credentials (#1352).
+- Added script sandbox execution for Workflow code nodes, with related node debugging and sandbox configuration support (#1333).
+- Added Astron Agent website deployment support for GitHub Pages and Vercel (#1344).
+
+### Security and Stability
+- Strengthened tool-debug redirect validation to reduce SSRF risk (#1338).
+- Hardened database DML execution checks to prevent SQL injection (#1340).
+- Fixed bot list sort direction handling to avoid invalid query parameters affecting query stability (#1342).
+- Fixed credential loading across AI Tools, Knowledge document upload, voice, and model invocation paths by moving them to platform account configuration (#1348).
+- Removed an unused Agent service database dependency to simplify service startup requirements (#1358).
+
+### Deployment and Documentation
+- Updated Docker Compose, Helm, Nginx, and authenticated deployment guides with platform account, gateway authentication, and core service configuration notes (#1348, #1352).
+- Aligned core router and workflow documentation to reduce integration and troubleshooting overhead (#1335).
+
+## Upgrade Notes
+- Before upgrading, review the Docker, Helm, and env example changes for platform account, AI Tools, Knowledge, and Workflow configuration.
+- If your deployment relies on health checks or gateway authentication, update the related gateway, tenant, and service configuration together.
+
+## Change Scope
+- 155 files changed: 6,629 insertions and 2,304 deletions.
+- Full comparison: https://github.com/iflytek/astron-agent/compare/v1.0.7...v1.0.8

--- a/docs/brain/inputs/langgenius_dify_v1.14.2.md
+++ b/docs/brain/inputs/langgenius_dify_v1.14.2.md
@@ -1,0 +1,226 @@
+# ℹ️ Intel Report: langgenius/dify
+## 🎯 监控目标 (Target)
+> langgenius/dify
+
+## 🚀 新版本发布 (New Release)
+> Version: 1.14.2
+> Date: 2026-06-08T04:59:03.203134
+
+## 💡 项目洞察 (Insight)
+> **Architect's Analysis**: ⚠️ Breaking-Change 🔗 Agent-Protocol
+
+## 🛡️ 信任评分 (Trust Score)
+> Score: 100/100
+
+## 🔨 最近提交 (Recent Commits)
+*Summary from release notes:*
+
+## 🚀 What's New in v1.14.2?
+
+v1.14.2 is a patch release focused on security hardening, workflow and knowledge reliability, observability fixes, agent groundwork, and deployment/runtime tuning after v1.14.1.
+
+### 🔐 Security and administration
+
+- **Tenant-scoped sensitive endpoints** — strengthened tenant isolation for app trace-config endpoints and FilePreview text extraction. Thanks @xr843 in [#35793](https://github.com/langgenius/dify/pull/35793) and [#35797](https://github.com/langgenius/dify/pull/35797).
+- **Tool credential safety** — restricted default builtin tool credential updates to workspace admins and owners, and cleaned stale tenant tool credentials during `reset-encrypt-key-pair`. Thanks @NeatGuyCoding and @xr843 in [#36264](https://github.com/langgenius/dify/pull/36264) and [#35843](https://github.com/langgenius/dify/pull/35843).
+
+### 🧩 Workflow, HITL, and app runtime
+
+- **Workflow execution reliability** — restored tracing after HITL workflow resume, improved workflow run callback tracking, reduced message-update database roundtrips, fixed memory fetches outside Flask context, and closed base64 file lookup sessions correctly. Thanks @Blackoutta, @CodingOnStar, @wylswz, @hjlarry, and @escape0707 in [#36064](https://github.com/langgenius/dify/pull/36064), [#36149](https://github.com/langgenius/dify/pull/36149), [#36213](https://github.com/langgenius/dify/pull/36213), [#36253](https://github.com/langgenius/dify/pull/36253), and [#36308](https://github.com/langgenius/dify/pull/36308).
+- **Workflow and model selection polish** — fixed loading behavior when no model is selected, filtered model presets by supported parameters, and improved API extension dialog controls. Thanks @iamjoel and @lyzno1 in [#36342](https://github.com/langgenius/dify/pull/36342), [#36339](https://github.com/langgenius/dify/pull/36339), and [#36323](https://github.com/langgenius/dify/pull/36323).
+
+### 📚 Data, RAG, and knowledge
+
+- **Knowledge-base stability** — fixed knowledge hit-testing rendering, empty knowledge creation, recommended app category ordering, and null handling in recommended app detail retrieval. Thanks @FFXN, @laipz8200, @hjlarry, and @EvanYao826 in [#36106](https://github.com/langgenius/dify/pull/36106), [#36336](https://github.com/langgenius/dify/pull/36336), [#36161](https://github.com/langgenius/dify/pull/36161), and [#36153](https://github.com/langgenius/dify/pull/36153).
+- **RAG and document processing** — allowed LLM nodes to access retrieved knowledge files, regenerated document summaries after API updates, fixed pipeline template rendering, and handled credential fetch failures in RAG pipelines more gracefully. Thanks @laipz8200, @EvanYao826, @FFXN, and @linw1995 in [#36175](https://github.com/langgenius/dify/pull/36175), [#36035](https://github.com/langgenius/dify/pull/36035), [#36168](https://github.com/langgenius/dify/pull/36168), and [#36165](https://github.com/langgenius/dify/pull/36165).
+
+### 🎨 Web UI and product experience
+
+- **App creation and onboarding** — tracked app creation source and template ID, initialized user timezone and language from the browser, and fixed WebApp icon and description display. Thanks @CodingOnStar, @lyzno1, and @JzoNgKVO in [#36369](https://github.com/langgenius/dify/pull/36369), [#36170](https://github.com/langgenius/dify/pull/36170), [#36206](https://github.com/langgenius/dify/pull/36206), and [#36209](https://github.com/langgenius/dify/pull/36209).
+- **Annotation and datasets UI** — allowed annotation reply score thresholds below `0.8`, redirected unauthorized knowledge editors back to datasets, and fixed tag rename without type payload. Thanks @JzoNgKVO, @iamjoel, and @lyzno1 in [#36337](https://github.com/langgenius/dify/pull/36337), [#36073](https://github.com/langgenius/dify/pull/36073), and [#36182](https://github.com/langgenius/dify/pull/36182).
+- **UI platform migration and polish** — added Checkbox and CheckboxGroup primitives, migrated more controls to `@langgenius/dify-ui`, improved dialog overflow layouts, and refined account avatar and install-flow interactions. Thanks @lyzno1 and @CodingOnStar in [#36271](https://github.com/langgenius/dify/pull/36271), [#36295](https://github.com/langgenius/dify/pull/36295), [#36255](https://github.com/langgenius/dify/pull/36255), [#36302](https://github.com/langgenius/dify/pull/36302), [#36111](https://github.com/langgenius/dify/pull/36111), [#36199](https://github.com/langgenius/dify/pull/36199), and [#36210](https://github.com/langgenius/dify/pull/36210).
+
+### 🔎 Observability and tracing
+
+- **Tracing reliability** — isolated Langfuse v3 SDK tracer providers to prevent cross-task interference and added Phoenix parent trace fallback behavior. Thanks @GareArc and @Blackoutta in [#36136](https://github.com/langgenius/dify/pull/36136) and [#36290](https://github.com/langgenius/dify/pull/36290).
+
+### ⚙️ Deployment, dependencies, and developer experience
+
+- **Deployment tuning** — upgraded plugin-daemon to `0.6.1`, increased the default GraphEngine minimum worker count, and refreshed Docker README references. Thanks @laipz8200, @kenwoodjw, and @RiskeyL in [#36312](https://github.com/langgenius/dify/pull/36312), [#35650](https://github.com/langgenius/dify/pull/35650), and [#36303](https://github.com/langgenius/dify/pull/36303).
+- **Backend and CI maintenance** — moved static analysis toward Pyrefly, upgraded Graphon to `0.4.0`, added hotfix cherry-pick provenance checks, and improved generated contract workflows. Thanks @cqjjjzr, @laipz8200, and @hyoban in [#36154](https://github.com/langgenius/dify/pull/36154), [#36124](https://github.com/langgenius/dify/pull/36124), [#36340](https://github.com/langgenius/dify/pull/36340), and [#36286](https://github.com/langgenius/dify/pull/36286).
+- **Dependency updates** — refreshed backend and agent dependencies including `authlib`, `ujson`, `langsmith`, and `urllib3`. Thanks @dependabot[bot] in [#36112](https://github.com/langgenius/dify/pull/36112), [#36121](https://github.com/langgenius/dify/pull/36121), [#36142](https://github.com/langgenius/dify/pull/36142), and [#36160](https://github.com/langgenius/dify/pull/36160).
+
+## Upgrade Guide
+
+> [!IMPORTANT]
+>
+> - This release includes a new database migration for configurable Explore app categories. Run database migrations as part of the upgrade.
+> - Docker Compose environment variables are now split into categorized files under `docker/envs/**`. If you maintain a customized `docker-compose.yaml` or `.env`, review the new layout and re-apply local customizations carefully.
+> - For self-hosted deployments, explicitly configured `SECRET_KEY` values continue to be respected. If `SECRET_KEY` is empty, Dify now generates and persists a runtime key automatically.
+
+### Docker Compose Deployments
+
+1. Back up your customized docker-compose YAML and env files.
+
+   ```bash
+   cd docker
+   cp docker-compose.yaml docker-compose.yaml.$(date +%s).bak
+   cp .env .env.$(date +%s).bak 2>/dev/null || true
+   ```
+
+2. Get the latest code from the release branch or tag.
+
+   ```bash
+   git fetch --tags
+   git checkout 1.14.2
+   ```
+
+3. Stop the service. Please execute in the `docker` directory.
+
+   ```bash
+   docker compose down
+   ```
+
+4. Back up data.
+
+   ```bash
+   tar -cvf volumes-$(date +%s).tgz volumes
+   ```
+
+5. Review the new `docker/envs/**` env file layout and re-apply any local customizations.
+
+6. Upgrade services.
+
+   ```bash
+   docker compose up -d
+   ```
+
+### Source Code Deployments
+
+1. Stop the API server, Worker, and Web frontend Server.
+
+2. Get the latest code from the release tag.
+
+   ```bash
+   git fetch --tags
+   git checkout 1.14.2
+   ```
+
+3. Update Python dependencies.
+
+   ```bash
+   cd api
+   uv sync
+   ```
+
+4. Run the migration script.
+
+   ```bash
+   uv run flask db upgrade
+   ```
+
+5. Restart the API server, Worker, and Web frontend Server.
+
+---
+
+## What's Changed
+* fix: redirect unauthorized dataset access to /datasets for knowledge editors by @iamjoel in https://github.com/langgenius/dify/pull/36073
+* chore: admin also has the permission of changing role by @iamjoel in https://github.com/langgenius/dify/pull/36069
+* fix: fixed relative by @CodingOnStar in https://github.com/langgenius/dify/pull/36078
+* chore: some match case by @asukaminato0721 in https://github.com/langgenius/dify/pull/36080
+* fix: fix plugin miss version and checksum by @fatelei in https://github.com/langgenius/dify/pull/36083
+* fix: restore tracing after HITL workflow resume by @Blackoutta in https://github.com/langgenius/dify/pull/36064
+* chore: update deps by @hyoban in https://github.com/langgenius/dify/pull/36091
+* fix: use Trans component for delete app confirmation text on editing page by @Copilot in https://github.com/langgenius/dify/pull/36092
+* refactor: stabilize selector preview cards by @lyzno1 in https://github.com/langgenius/dify/pull/36105
+* ci: Update pyrefly dependency version to 1.0.0 by @asukaminato0721 in https://github.com/langgenius/dify/pull/36100
+* fix: knowledge hit-testing render failed. by @FFXN in https://github.com/langgenius/dify/pull/36106
+* chore: remove obsolete admin console routes by @hjlarry in https://github.com/langgenius/dify/pull/35637
+* fix(web): refine account avatar interactions by @lyzno1 in https://github.com/langgenius/dify/pull/36111
+* chore(deps): bump ujson from 5.12.0 to 5.12.1 in /api by @dependabot[bot] in https://github.com/langgenius/dify/pull/36112
+* chore(i18n): sync translations with en-US by @github-actions[bot] in https://github.com/langgenius/dify/pull/36115
+* chore(deps): bump authlib from 1.6.11 to 1.6.12 in /api by @dependabot[bot] in https://github.com/langgenius/dify/pull/36121
+* fix: isolate Langfuse v3 SDK TracerProvider to prevent cross-task interference by @GareArc in https://github.com/langgenius/dify/pull/36136
+* chore(deps): bump langsmith from 0.7.31 to 0.8.0 in /api by @dependabot[bot] in https://github.com/langgenius/dify/pull/36142
+* fix: credit pool access outside flask context by @hjlarry in https://github.com/langgenius/dify/pull/36143
+* fix: fix pydantic union type error by @fatelei in https://github.com/langgenius/dify/pull/36134
+* fix(errors): clean unnecessary | None in error classes by @mturac in https://github.com/langgenius/dify/pull/36135
+* chore: drop unnecessary | None on LLMError and Mail.send by @BrianWang1990 in https://github.com/langgenius/dify/pull/36147
+* chore: Remove pyright in favor of pyrefly by @cqjjjzr in https://github.com/langgenius/dify/pull/36154
+* chore: enchance notify link ui by @iamjoel in https://github.com/langgenius/dify/pull/36155
+* feat(agent): init agent server by @BeautyyuYanli in https://github.com/langgenius/dify/pull/36087
+* feat(workflow): enhance workflow run callbacks with additional data tracking by @CodingOnStar in https://github.com/langgenius/dify/pull/36149
+* chore(deps): bump urllib3 from 2.6.3 to 2.7.0 in /dify-agent by @dependabot[bot] in https://github.com/langgenius/dify/pull/36160
+* fix: get recommend_app categories should not re-order it by @hjlarry in https://github.com/langgenius/dify/pull/36161
+* fix: add null check in get_recommend_app_detail before accessing result['id'] by @EvanYao826 in https://github.com/langgenius/dify/pull/36153
+* feat: allow disabling run time cred check by @wylswz in https://github.com/langgenius/dify/pull/36031
+* fix: fix delete logs failed by @fatelei in https://github.com/langgenius/dify/pull/36151
+* fix(api): gracefully handle credential fetch failures in rag pipeline by @linw1995 in https://github.com/langgenius/dify/pull/36165
+* feat(MessageLogModal): refactor modal structure and improve tab handling by @CodingOnStar in https://github.com/langgenius/dify/pull/36169
+* fix: pipeline template render by @FFXN in https://github.com/langgenius/dify/pull/36168
+* chore: increase default graph engine min workers by @kenwoodjw in https://github.com/langgenius/dify/pull/35650
+* fix: action btn is hidden if  there are many packages to install by @iamjoel in https://github.com/langgenius/dify/pull/36176
+* refactor: cleanup duplicate code by @cqjjjzr in https://github.com/langgenius/dify/pull/36173
+* refactor(api): migrate console.app.workflow_comment to BaseModel by @cqjjjzr in https://github.com/langgenius/dify/pull/36180
+* fix(api): allow LLM nodes to access retrieved knowledge files by @laipz8200 in https://github.com/langgenius/dify/pull/36175
+* fix(security): enforce tenant scoping on app trace-config endpoints (GHSA-48xc-wmw8-3jr3) by @xr843 in https://github.com/langgenius/dify/pull/35793
+* fix(security): tenant-scope FilePreviewApi text-extract endpoint (GHSA-2qwc-c2cc-2xwv) by @xr843 in https://github.com/langgenius/dify/pull/35797
+* fix(commands): purge tenant tool credentials on reset-encrypt-key-pair (#35396) by @xr843 in https://github.com/langgenius/dify/pull/35843
+* fix: allow tag rename without type payload by @lyzno1 in https://github.com/langgenius/dify/pull/36182
+* fix: replace deprecated testcontainers log waits by @KurodaKayn in https://github.com/langgenius/dify/pull/36125
+* refactor(install): improve layout and scrolling behavior for plugin installation step by @CodingOnStar in https://github.com/langgenius/dify/pull/36199
+* chore: enchance copywriting in none education plan warning modal by @iamjoel in https://github.com/langgenius/dify/pull/36201
+* chore(layout): reintroduce AmplitudeProvider in common layouts for analytics tracking by @CodingOnStar in https://github.com/langgenius/dify/pull/36208
+* refactor: enhance layout and scrolling behavior in various modals for improved user experience by @CodingOnStar in https://github.com/langgenius/dify/pull/36210
+* fix: regenerate document summary after update via API (#35950) by @EvanYao826 in https://github.com/langgenius/dify/pull/36035
+* fix(web): app icon in webapp by @JzoNgKVO in https://github.com/langgenius/dify/pull/36206
+* fix(web): web app description missing by @JzoNgKVO in https://github.com/langgenius/dify/pull/36209
+* feat: initialize user timezone and language from browser by @lyzno1 in https://github.com/langgenius/dify/pull/36170
+* fix(api): avoid dify-agent path lookup during Docker build by @BeautyyuYanli in https://github.com/langgenius/dify/pull/36187
+* fix: reduce db roundtrips of message update by @wylswz in https://github.com/langgenius/dify/pull/36213
+* refactor: convert isinstance chains to match/case in easy_ui_based_generate_task_pipeline.py by @EvanYao826 in https://github.com/langgenius/dify/pull/36222
+* refactor: convert isinstance chains to match/case (part 3) by @EvanYao826 in https://github.com/langgenius/dify/pull/36242
+* fix: fetch memory of LLM node may cause out of flask context by @hjlarry in https://github.com/langgenius/dify/pull/36253
+* chore: improve swagger markdown optional fields typing by @cqjjjzr in https://github.com/langgenius/dify/pull/36247
+* fix(web): migrate metadata picker to combobox by @zhangxuhe1 in https://github.com/langgenius/dify/pull/36255
+* fix(auth): preserve `phase` field in `_TokenData` so reset-password / change-email phase-bound checks don't 400 (#36116) by @vuko in https://github.com/langgenius/dify/pull/36117
+* refactor: use match cases for workflow stream responses by @D-393Patel in https://github.com/langgenius/dify/pull/36267
+* chore(api): upgrade graphon to 0.4.0 by @laipz8200 in https://github.com/langgenius/dify/pull/36124
+* feat(dify-ui): add Checkbox/CheckboxGroup primitives by @lyzno1 in https://github.com/langgenius/dify/pull/36271
+* fix: add missing phase field to _TokenData TypedDict by @xxiaoxiong in https://github.com/langgenius/dify/pull/36261
+* chore: generate contract in ci by @hyoban in https://github.com/langgenius/dify/pull/36286
+* refactor: migrate checkbox to dify-ui by @lyzno1 in https://github.com/langgenius/dify/pull/36295
+* fix(web): constrain dialog overflow layouts by @lyzno1 in https://github.com/langgenius/dify/pull/36302
+* refactor(web): simplify github install focus by @lyzno1 in https://github.com/langgenius/dify/pull/36314
+* chore(docker): upgrade plugin daemon to 0.6.1 by @laipz8200 in https://github.com/langgenius/dify/pull/36312
+* ci: ensure pnpm is available in setup-web action by @lyzno1 in https://github.com/langgenius/dify/pull/36315
+* fix: use Generator type annotation with @contextmanager decorators by @EvanYao826 in https://github.com/langgenius/dify/pull/36297
+* fix(api): close base64 file lookup sessions by @escape0707 in https://github.com/langgenius/dify/pull/36308
+* refactor: convert isinstance chains to match/case (part 5) by @EvanYao826 in https://github.com/langgenius/dify/pull/36298
+* refactor(api): migrate console.app.workflow to BaseModel by @cqjjjzr in https://github.com/langgenius/dify/pull/36216
+* refactor: add console client migration demo by @hyoban in https://github.com/langgenius/dify/pull/36300
+* fix: improve API extension dialog controls by @lyzno1 in https://github.com/langgenius/dify/pull/36323
+* fix(dev): handle empty pyrefly target paths by @laipz8200 in https://github.com/langgenius/dify/pull/36325
+* chore: add type to test by @asukaminato0721 in https://github.com/langgenius/dify/pull/36324
+* test(api): isolate container DB between tests by @escape0707 in https://github.com/langgenius/dify/pull/36310
+* fix: fallback phoenix parent trace when parent tracing disabled by @Blackoutta in https://github.com/langgenius/dify/pull/36290
+* fix: can not create empty knowledge by @laipz8200 in https://github.com/langgenius/dify/pull/36336
+* chore: Filter model presets by supported parameters by @iamjoel in https://github.com/langgenius/dify/pull/36339
+* ci: add hotfix cherry-pick provenance check by @laipz8200 in https://github.com/langgenius/dify/pull/36340
+* feat(web): allow annotation reply score threshold below 0.8 by @JzoNgKVO in https://github.com/langgenius/dify/pull/36337
+* fix(console): require admin/owner to set default builtin tool credential by @NeatGuyCoding in https://github.com/langgenius/dify/pull/36264
+* docs: fix docker README numbering and refresh stale references by @RiskeyL in https://github.com/langgenius/dify/pull/36303
+* fix: no model selected but params keep loading by @iamjoel in https://github.com/langgenius/dify/pull/36342
+* fix(offline): guard marketplace I/O paths for ENG-421 by @GareArc in https://github.com/langgenius/dify/pull/36335
+* feat: enhance app creation tracking with source and template ID by @CodingOnStar in https://github.com/langgenius/dify/pull/36369
+* chore(release): bump version to 1.14.2 by @laipz8200 in https://github.com/langgenius/dify/pull/36313
+
+## New Contributors
+* @mturac made their first contribution in https://github.com/langgenius/dify/pull/36135
+* @linw1995 made their first contribution in https://github.com/langgenius/dify/pull/36165
+* @KurodaKayn made their first contribution in https://github.com/langgenius/dify/pull/36125
+* @vuko made their first contribution in https://github.com/langgenius/dify/pull/36117
+* @D-393Patel made their first contribution in https://github.com/langgenius/dify/pull/36267
+* @xxiaoxiong made their first contribution in https://github.com/langgenius/dify/pull/36261
+
+**Full Changelog**: https://github.com/langgenius/dify/compare/1.14.1...1.14.2

--- a/docs/brain/inputs/microsoft_markitdown_v0.1.6.md
+++ b/docs/brain/inputs/microsoft_markitdown_v0.1.6.md
@@ -1,0 +1,28 @@
+# ℹ️ Intel Report: microsoft/markitdown
+## 🎯 监控目标 (Target)
+> microsoft/markitdown
+
+## 🚀 新版本发布 (New Release)
+> Version: v0.1.6
+> Date: 2026-06-08T04:59:03.320264
+
+## 🛡️ 信任评分 (Trust Score)
+> Score: 80/100
+
+## 🔨 最近提交 (Recent Commits)
+*Summary from release notes:*
+
+## What's Changed
+* [MS] Add OCR layer service for embedded images and PDF scans by @lesyk in https://github.com/microsoft/markitdown/pull/1541
+* Fix O(n) memory growth in PDF conversion by calling page.close() afte… by @lesyk in https://github.com/microsoft/markitdown/pull/1612
+* Updated warning about binding to non-local interfaces. by @afourney in https://github.com/microsoft/markitdown/pull/1653
+* fix: handle deeply nested HTML that triggers RecursionError by @jigangz in https://github.com/microsoft/markitdown/pull/1644
+* Clarify security posture in READMEs by @afourney in https://github.com/microsoft/markitdown/pull/1807
+* feat: Add Azure Content Understanding converter by @chienyuanchang in https://github.com/microsoft/markitdown/pull/1865
+* Bump version to 0.1.6 by @afourney in https://github.com/microsoft/markitdown/pull/1914
+
+## New Contributors
+* @jigangz made their first contribution in https://github.com/microsoft/markitdown/pull/1644
+* @chienyuanchang made their first contribution in https://github.com/microsoft/markitdown/pull/1865
+
+**Full Changelog**: https://github.com/microsoft/markitdown/compare/v0.1.5...v0.1.6

--- a/docs/brain/inputs/vllm-project_vllm_v0.22.1.md
+++ b/docs/brain/inputs/vllm-project_vllm_v0.22.1.md
@@ -1,0 +1,46 @@
+# ℹ️ Intel Report: vllm-project/vllm
+## 🎯 监控目标 (Target)
+> vllm-project/vllm
+
+## 🚀 新版本发布 (New Release)
+> Version: v0.22.1
+> Date: 2026-06-08T04:59:03.180131
+
+## 💡 项目洞察 (Insight)
+> **Architect's Analysis**: 🏷️ Edge-Ready ⚠️ Breaking-Change
+
+## 🛡️ 信任评分 (Trust Score)
+> Score: 100/100
+
+## 🔨 最近提交 (Recent Commits)
+*Summary from release notes:*
+
+## Highlights
+
+This release features 8 commits from 6 contributors (1 new)!
+
+v0.22.1 is a patch release on top of v0.22.0 with targeted bug fixes plus a couple of additions: new model support for JetBrains' Mellum v2, zentorch-accelerated quantized linear inference on AMD Zen CPUs, and fixes for multi-node Ray data-parallel serving, DeepSeek-V4 initialization, and a few model-loading regressions.
+
+### Model Support
+* New model: JetBrains' **Mellum v2**, an open-weights Mixture-of-Experts code-generation model (#43992).
+* **DeepSeek-V4**: resolve a CUTLASS `fmin` compatibility issue that broke initialization (0decac0d).
+* Fix `OlmoHybridForCausalLM` failing to initialise after the checkpoint changed `rope_parameters` from `None` to `{"rope_type": None}` (#43846).
+* Fix **HyperCLOVAX** loading after the upstream HuggingFace repo removed its remote code (now native in `transformers >= 5.9.0`): register the `hyperclovax` model_type so vLLM uses its vendored config instead of the stale `auto_map` (#43860).
+
+### Hardware & Performance
+* **AMD Zen CPUs**: route W8A8 (int8 dynamic-symmetric) and W4A16 (GPTQ) linear inference through zentorch kernels, registered ahead of the generic oneDNN CPU kernels, with transparent fallback on non-Zen CPUs, GPUs, and XPU (#41813).
+
+### Large Scale Serving
+* Fix a deterministic hang in multi-node **Ray data-parallel** serving with `num_api_servers > 1` by excluding the Ray DP backend from the deferred (kernel-assigned) port allocation introduced in #42585 (#43864).
+
+### Build & CI
+* Docker: stop installing `flashinfer-jit-cache` via `--extra-index-url` while it is quarantined on PyPI, fixing image builds (#44366).
+* Normalize **NIXL** KV-connector wheel installs so only the wheel matching the image's CUDA major is kept, fixing `ImportError: libcudart.so.12` when importing `nixl_ep` on CUDA 13 images (#44266).
+
+## Contributors
+
+@khluu, @vadiklyutiy, @aadwived, @shadeMe, @alec-flowers, @hmellor
+
+## New Contributors
+
+* @aadwived made their first contribution in https://github.com/vllm-project/vllm/pull/41813


### PR DESCRIPTION
Executed the W1 Intelligence Transporter protocol to harvest the latest release notes from the ecosystem targets. Since the truncation logic (`[:3000]`) had already been removed from `docs/brain/harvester.py` in an earlier commit, the newly generated intelligence files in `docs/brain/inputs/` securely contain the full descriptions without arbitrary string splicing. Added the newly fetched `.md` reports under the designated folder.

---
*PR created automatically by Jules for task [1332330029951067419](https://jules.google.com/task/1332330029951067419) started by @lostlight530*