### PR TITLE
[W4] Archaeology Index 2026-W24

### DIFF
--- a/docs/archaeology/ARCHAEOLOGY_INDEX.md
+++ b/docs/archaeology/ARCHAEOLOGY_INDEX.md
@@ -26,3 +26,8 @@ Legacy files are permanently archived under `legacy_traces/` to adhere to Append
 ### 2026-06-08 架构扫描记录
 * **扫描结果**: `No legacy files migrated this week.`
 * **系统状态**: 历史归档区保持静默，无覆写或删改动作。
+
+### [2026-06-14] 架构迁移记录
+* **迁移来源**: `docs/brain/memories/` 等日常活动目录
+* **考古归宿**: `docs/archaeology/legacy_traces/` (包含 18 个日常 Dashboard, 18 个 Mission 文件及部分旧版核心思考如 `system-architecture-analysis.md` 等)
+* **封存原因**: 根据 PHASE VI 与 PHASE VII 演进准则，系统已完全废弃基于主观语言描述的认知报告与碎片化的每日文件，全面收敛为基于数学图谱与绝对决定论的中央自动化记录。旧日遗迹被安全移入归档区。


### PR DESCRIPTION
Added entries to docs/archaeology/ARCHAEOLOGY_INDEX.md detailing the recent bulk migration of 18 Quantitative Dashboards, 18 MISSION logs, and various historical architecture deep-dives (such as the legacy `system-architecture-analysis.md`) into the `docs/archaeology/legacy_traces/` archive directory.

This fulfills the W4 Weekly Archaeology Index mandate strictly formatting with H3 headers, code-fenced paths, and human-friendly language explaining the transition from subjective textual reports to deterministic, quantitative mathematical dashboards based on Phase VI/VII evolution.

---
*PR created automatically by Jules for task [14312055803108602365](https://jules.google.com/task/14312055803108602365) started by @lostlight530*