### PR TITLE
Add 2026-06-30 H1 daily signal observation report

### DIFF
--- a/horizon-cortex/2026-06-30-H1-signal-observe.md
+++ b/horizon-cortex/2026-06-30-H1-signal-observe.md
@@ -1,0 +1,91 @@
+H1 Daily Signal Observe
+
+CORTEX_RUN_HEADER
+
+Cortex: horizon-cortex
+
+Host Repository: welcome-to-github
+
+Task ID: H1
+
+Cadence: Daily
+
+Loop Stage: Observe
+
+Run Date: 2026-06-30
+
+Agent: Jules
+
+Knowledge Source: External Web + horizon-cortex local files
+
+Repository Inspection: NO
+
+GitHub Actions Inspection: NO
+
+Write Scope: horizon-cortex only
+
+Boundary Violation: NO
+
+INPUT_RECORD
+
+Local Files Read:
+horizon-cortex/sample-2026-07-01-H1-signal-observe.md
+
+External Topics Searched:
+"AI Agent" OR "Coding Agent" OR "MCP" OR "Agent workflow" recent news
+"Model Context Protocol" news
+"Coding agent" news
+
+Why Observed:
+To monitor updates in external AI infrastructures, agent capabilities, and developer tooling ecosystems per Task H1's mandate.
+
+EXTERNAL_SOURCE_RECORDS
+
+Source 1
+
+Title: NSA Releases Security Design Considerations for AI-Driven Automation Leveraging the Model Context Protocol
+Publisher: NSA
+URL: https://www.nsa.gov/Press-Room/Press-Releases-Statements/Press-Release-View/Article/4496698/nsa-releases-security-design-considerations-for-ai-driven-automation-leveraging/
+Date Checked: 2026-06-30
+Source Type: Official press release / Security advisory
+Relevance: Directly addresses Model Context Protocol (MCP) security in AI-enabled systems, indicating accelerating adoption.
+Confidence: High
+
+Source 2
+
+Title: Junie: The JetBrains AI Coding Agent Leaves Beta
+Publisher: JetBrains
+URL: https://blog.jetbrains.com/junie/2026/06/junie-coding-agent-out-of-beta/
+Date Checked: 2026-06-30
+Source Type: Official company blog
+Relevance: Confirms advancement in coding agents, moving from beta to stable, integration with IDEs and capability in PR reviews and SWE-Rebench.
+Confidence: High
+
+RAW_SIGNAL_LOG
+
+Signal 1
+
+Signal: The NSA has released security design considerations (CSI) for the Model Context Protocol (MCP), highlighting its rapid adoption across various industries for managing interactions between services in AI-driven systems.
+Source: NSA Press Release
+Why It May Matter: Highlights the growing importance and security implications of MCP in agentic workflows.
+Uncertainty: Low (official government release).
+
+Signal 2
+
+Signal: JetBrains' AI coding agent, Junie, has left beta, claiming top position on SWE-Rebench and supporting flexible model choice to manage costs.
+Source: JetBrains Blog
+Why It May Matter: Indicates maturation of coding agents towards stable, production-ready tools integrated directly into developer workflows.
+Uncertainty: Low for product release; Medium for independent benchmark verification over time.
+
+NEXT_HANDOFF
+
+Orient Task (H2) Input:
+- The NSA's security guidelines for MCP need to be interpreted regarding their impact on our agent workflow and security posture. Does this require changes in how we handle tools?
+- JetBrains' Junie leaving beta and its SWE-Rebench performance might signal a shift in developer tooling standards.
+- No immediate noise identified; both signals are strong and from official sources.
+
+BOUNDARY_CHECK
+
+Confirmed no host repository mechanism was inspected.
+Confirmed no GitHub Actions were inspected.
+Confirmed no files outside horizon-cortex were written.

--- a/horizon-cortex/2026-06-30-H1-signal-observe.md
+++ b/horizon-cortex/2026-06-30-H1-signal-observe.md
@@ -35,6 +35,9 @@ External Topics Searched:
 "AI Agent" OR "Coding Agent" OR "MCP" OR "Agent workflow" recent news
 "Model Context Protocol" news
 "Coding agent" news
+"Google Labs" early access OR "Gemini" OR "AI Studio" recent news
+"Google Maps Grounding" OR "Open source governance" OR "Async execution" OR "Agent reliability" news
+"Agentjacking" "AI coding agents" news
 
 Why Observed:
 To monitor updates in external AI infrastructures, agent capabilities, and developer tooling ecosystems per Task H1's mandate.
@@ -61,6 +64,26 @@ Source Type: Official company blog
 Relevance: Confirms advancement in coding agents, moving from beta to stable, integration with IDEs and capability in PR reviews and SWE-Rebench.
 Confidence: High
 
+Source 3
+
+Title: Google launches Gemini for Science as AI research tools open in Labs
+Publisher: EdTech Innovation Hub
+URL: https://www.edtechinnovationhub.com/news/google-launches-gemini-for-science-as-ai-research-tools-open-in-labs
+Date Checked: 2026-06-30
+Source Type: Tech news
+Relevance: Shows Google's expansion into agentic AI for scientific discovery and early access through Google Labs.
+Confidence: High
+
+Source 4
+
+Title: Fake Bug Report Hijacks AI Coding Agents at Scale - Dark Reading
+Publisher: Dark Reading (Tenet Security Research)
+URL: https://www.darkreading.com/cyber-risk/fake-bug-report-hijacks-ai-coding-agents
+Date Checked: 2026-06-30
+Source Type: Cyber security news
+Relevance: Details "Agentjacking", a critical vulnerability in AI coding agents retrieving poisoned error data (e.g. via MCP from Sentry).
+Confidence: High
+
 RAW_SIGNAL_LOG
 
 Signal 1
@@ -77,12 +100,27 @@ Source: JetBrains Blog
 Why It May Matter: Indicates maturation of coding agents towards stable, production-ready tools integrated directly into developer workflows.
 Uncertainty: Low for product release; Medium for independent benchmark verification over time.
 
+Signal 3
+
+Signal: Google launched Gemini for Science with experimental research tools (Literature Insights, Hypothesis Generation, Computational Discovery) rolling out via Google Labs.
+Source: EdTech Innovation Hub
+Why It May Matter: Highlights Google Labs as a primary surface for agentic AI experiments in specialized domains.
+Uncertainty: Low.
+
+Signal 4
+
+Signal: "Agentjacking" vulnerability allows attackers to hijack AI coding agents by planting malicious instructions in fake bug reports (like Sentry errors retrieved via MCP). The agent runs the attacker's code locally.
+Source: Dark Reading / Tenet Security
+Why It May Matter: This represents a critical supply-chain/execution risk for coding agents leveraging external context via MCP without strict input sanitization.
+Uncertainty: Low (confirmed research proof of concept).
+
 NEXT_HANDOFF
 
 Orient Task (H2) Input:
 - The NSA's security guidelines for MCP need to be interpreted regarding their impact on our agent workflow and security posture. Does this require changes in how we handle tools?
+- "Agentjacking" risk via MCP is a critical security signal. H2 should assess if our agent workflows are vulnerable to poisoned context.
 - JetBrains' Junie leaving beta and its SWE-Rebench performance might signal a shift in developer tooling standards.
-- No immediate noise identified; both signals are strong and from official sources.
+- Google Labs introducing Gemini for Science confirms our watchlist focus on Labs as a key experimental surface.
 
 BOUNDARY_CHECK
 


### PR DESCRIPTION
Creates `horizon-cortex/2026-06-30-H1-signal-observe.md` strictly following the requested structure for the daily signal observation task. Information harvested includes updates on MCP security by the NSA and JetBrains Junie coding agent leaving beta. Verified zero boundary violations or file artifacts outside `horizon-cortex`.

---
*PR created automatically by Jules for task [5248652087678170983](https://jules.google.com/task/5248652087678170983) started by @lostlight530*