### PR TITLE
H2 Daily Horizon Orient 2026-07-02

### DIFF
--- a/horizon-cortex/2026-07-02-H2-horizon-orient.md
+++ b/horizon-cortex/2026-07-02-H2-horizon-orient.md
@@ -1,0 +1,84 @@
+H2 Daily Horizon Orient
+
+CORTEX_RUN_HEADER
+
+Cortex: horizon-cortex
+Host Repository: welcome-to-github
+Task ID: H2
+Cadence: Daily
+Loop Stage: Orient
+Run Date: 2026-07-02
+Agent: Jules
+Knowledge Source: H1 input + External Web + horizon-cortex local files
+Repository Inspection: NO
+GitHub Actions Inspection: NO
+Write Scope: horizon-cortex only
+Boundary Violation: NO
+
+INPUT_RECORD
+
+INPUT_MISSING
+
+记录读取的 H1 文件路径:
+今日无 H1 文件 (No H1 file today)
+
+记录读取的历史 horizon-cortex 文件路径:
+horizon-cortex/2026-07-01-H1-signal-observe.md
+horizon-cortex/2026-07-01-H2-horizon-orient.md
+horizon-cortex/sample-2026-07-H6-horizon-memorize.md
+
+记录本次联网验证的主题和来源:
+今日因无 H1 信号，未进行外部联网验证 (No external verification conducted today due to missing H1 input)
+
+SIGNAL_CLASSIFICATION
+
+ignore
+
+信号 (Signal): 无输入 (No input)
+原因 (Reason): 今日无输入，跳过分类 (No input today, skipping classification)
+
+ORIENTATION_NOTES
+
+说明今日信号对 horizon-cortex 自身意味着什么:
+今日无新信号，维持 2026-07-01 建立的基调，即关注 Agent 的外部执行上下文（如 MCP）的安全防御和边界管控
+
+说明哪些外部知识会影响未来 Jules 的观察重点:
+未来应继续大幅增加对 Agent 安全架构、MCP 漏洞以及供应链投毒攻击的关注，而不仅仅是追踪新功能的发布
+
+说明哪些判断仍然不确定:
+虽然安全风险已明确，但业界将如何快速响应并建立标准化的 MCP 安全防护机制尚不清晰，需继续观察生态演变以及各大厂商的应对策略
+
+NO_DECISION_SECTION
+
+明确列出今天不做的决策:
+不决定本周的重点战略方向
+不改变当前的任务执行频率和模式
+不决定具体的安全防御机制实现方案
+
+明确列出今天不能修改的内容:
+不修改宿主仓库的任何代码或配置
+不更新 README 或 GitHub Actions
+不修改 Nexus 记忆体
+
+NEXT_HANDOFF
+
+写给 H3 的周决策输入:
+强烈建议评估是否将 "Agent 安全与信任边界" 作为本周的核心战略议题
+考虑如何调整外部信号观察的优先级，使其更侧重于基础设施的稳定性与安全性，特别是 MCP 相关的安全动态
+建议将 Agentjacking 列为高优威胁模型进行追踪
+
+列出本周候选方向:
+深化对 MCP 安全生态的追踪和防御策略研究
+持续关注从研发走向生产环境的成熟 Agent 工具的演进
+探索在不增加外部依赖的情况下如何增强本地执行的鲁棒性
+
+列出需要继续观察的信号:
+业界针对 Agentjacking 的防御方案和最佳实践
+NSA 安全指南对其他云服务商和开源社区的影响
+生产级 Agent 的广泛采纳度和实际效能反馈
+
+BOUNDARY_CHECK
+
+确认没有读取宿主仓库机制
+确认没有读取 GitHub Actions
+确认没有写入 horizon-cortex 之外的文件


### PR DESCRIPTION
Adds the daily H2 Horizon Orient markdown file for 2026-07-02, addressing the missing H1 input signal correctly and following the strict structural guidelines for horizon-cortex without triggering Chinese period violations.

---
*PR created automatically by Jules for task [110232947906142694](https://jules.google.com/task/110232947906142694) started by @lostlight530*