### PR TITLE
Add H2 daily horizon orient record for 2026-07-04

### DIFF
--- a/horizon-cortex/2026-07-04-H2-horizon-orient.md
+++ b/horizon-cortex/2026-07-04-H2-horizon-orient.md
@@ -1,0 +1,76 @@
+H2 Daily Horizon Orient
+
+CORTEX_RUN_HEADER
+
+Cortex: horizon-cortex
+Host Repository: welcome-to-github
+Task ID: H2
+Cadence: Daily
+Loop Stage: Orient
+Run Date: 2026-07-04
+Agent: Jules
+Knowledge Source: H1 input + External Web + horizon-cortex local files
+Repository Inspection: NO
+GitHub Actions Inspection: NO
+Write Scope: horizon-cortex only
+Boundary Violation: NO
+
+INPUT_RECORD
+
+INPUT_MISSING
+
+记录读取的 H1 文件路径:
+今日无 H1 文件
+
+记录读取的历史 horizon-cortex 文件路径:
+horizon-cortex/2026-07-03-H2-horizon-orient.md
+horizon-cortex/sample-2026-07-H6-horizon-memorize.md
+
+记录本次联网验证的主题和来源:
+今日无输入信号，无需外部验证
+
+SIGNAL_CLASSIFICATION
+
+ignore
+
+信号: 无输入
+原因: 今日无 H1 文件，跳过分类
+
+ORIENTATION_NOTES
+
+说明今日信号对 horizon-cortex 自身意味着什么:
+今日无新信号，维持近期关于 Agent 安全和 MCP 防御的关注焦点
+
+说明哪些外部知识会影响未来 Jules 的观察重点:
+未有新知识摄入，继续追踪供应链安全与生态系统的应对措施
+
+说明哪些判断仍然不确定:
+安全标准的普及速度及具体防御框架仍不明朗，需长期观察
+
+NO_DECISION_SECTION
+
+明确列出今天不做的决策:
+不修改任务执行计划
+不改变当前的安全监控基调
+
+明确列出今天不能修改的内容:
+不修改宿主仓库的任何代码或配置
+不读取 GitHub Actions 或 README
+不向 horizon-cortex 外部写入文件
+
+NEXT_HANDOFF
+
+写给 H3 的周决策输入:
+继续评估将安全和防御作为重点考察维度
+
+列出本周候选方向:
+研究成熟工具的演进路线和安全机制建设
+
+列出需要继续观察的信号:
+针对已知风险的实践解决方案和社区反馈
+
+BOUNDARY_CHECK
+
+确认没有读取宿主仓库机制
+确认没有读取 GitHub Actions
+确认没有写入 horizon-cortex 之外的文件


### PR DESCRIPTION
Creates the H2 Daily Horizon Orient record for 2026-07-04. As no H1 file was present, properly records `INPUT_MISSING` and follows the boundaries indicating no modifications or inspections of host repository mechanisms. Does not include Chinese periods.

---
*PR created automatically by Jules for task [5346957379235429189](https://jules.google.com/task/5346957379235429189) started by @lostlight530*