### PR TITLE
ci: Add diagnostic file listing to GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,13 @@ jobs:
         with:
           enablement: true
 
+      - name: Show files to be uploaded
+        run: |
+          echo "Listing repository root:"
+          ls -la
+          echo "Recursive listing:"
+          ls -R
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
This PR adds diagnostic `ls` steps to the `deploy.yml` workflow right before the artifact upload step.

As requested by the user, this implementation aligns with "Option A" to diagnose the GitHub Pages deployment failure by outputting the repository root and its recursive files (`ls -la` and `ls -R`). This will help identify if the artifact being uploaded contains the correct files (like `index.html`) or if unexpected files are causing issues without changing the overall build architecture since the project relies on native ES modules and Tailwind CDN.

---
*PR created automatically by Jules for task [15280523830779843889](https://jules.google.com/task/15280523830779843889) started by @lostlight530*