### PR TITLE
fix: remove FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 and reset ci artifact state

### DIFF
--- a/.github/workflows/nexus-life-cycle.yml
+++ b/.github/workflows/nexus-life-cycle.yml
@@ -11,7 +11,6 @@ on:
 
 env:
   GITHUB_DEPENDENCY_GRAPH_ENABLED: 'false'
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 
 jobs:


### PR DESCRIPTION
The deployment using `.github/workflows/nexus-life-cycle.yml` failed due to an issue with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'`. The actions that target Node.js 20 were being forced to run on Node.js 24 resulting in multiple artifacts errors. I removed `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` from `nexus-life-cycle.yml` and added an empty commit to reset the CI/CD state as mentioned in guidelines.

---
*PR created automatically by Jules for task [15138195138771067425](https://jules.google.com/task/15138195138771067425) started by @lostlight530*