### PR TITLE
Add 2026-07-04 H1 Signal Observe File

### DIFF
--- a/horizon-cortex/2026-07-04-H1-signal-observe.md
+++ b/horizon-cortex/2026-07-04-H1-signal-observe.md
@@ -1,0 +1,108 @@
+CORTEX_RUN_HEADER
+
+Cortex: horizon-cortex
+Host Repository: welcome-to-github
+Task ID: H1
+Cadence: Daily
+Loop Stage: Observe
+Run Date: 2026-07-04
+Agent: Jules
+Knowledge Source: External Web + horizon-cortex local files
+Repository Inspection: NO
+GitHub Actions Inspection: NO
+Write Scope: horizon-cortex only
+Boundary Violation: NO
+
+INPUT_RECORD
+
+本次读取的 horizon-cortex 文件:
+horizon-cortex/2026-07-03-H1-signal-observe.md
+
+本次联网搜索的主题:
+"AI Agent" "Coding Agent" latest news 2026
+"Model Context Protocol" "MCP" latest updates 2026
+"Google Maps Grounding" Gemini "AI Studio" 2026
+"Agent workflow" "Async execution" "Agent reliability" 2026
+
+每个主题为什么需要观察:
+根据任务要求，监控 AI Agent、MCP、Coding Agent、Google Labs 及 Agent 工作流的前沿动态，为后续任务提供最新的外部信号支撑.
+
+EXTERNAL_SOURCE_RECORDS
+
+Title: Best AI Coding Agents in 2026: Top Tools by Use Case - Coursiv
+Publisher: Coursiv
+URL: https://coursiv.io/blog/best-ai-agents-for-coding-2026
+Date Checked: 2026-07-04
+Source Type: Blog Post
+Relevance: High
+Confidence: Medium
+
+Title: The biggest MCP spec update ships July 28: What changes for AI agent authentication
+Publisher: WorkOS
+URL: https://workos.com/blog/mcp-2026-spec-agent-authentication
+Date Checked: 2026-07-04
+Source Type: Blog Post
+Relevance: High
+Confidence: High
+
+Title: The 2026-07-28 MCP Specification Release Candidate | Model Context Protocol Blog
+Publisher: Model Context Protocol Blog
+URL: https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/
+Date Checked: 2026-07-04
+Source Type: Official Blog
+Relevance: High
+Confidence: High
+
+Title: Grounding with Google Maps in Gemini Enterprise Agent Platform
+Publisher: Google Cloud Docs
+URL: https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/grounding/grounding-with-google-maps
+Date Checked: 2026-07-04
+Source Type: Official Documentation
+Relevance: High
+Confidence: High
+
+Title: Google AI Studio Tutorial: Complete Guide to Chat, Build, and Stream Modes | DataCamp
+Publisher: DataCamp
+URL: https://www.datacamp.com/tutorial/google-ai-studio-tutorial
+Date Checked: 2026-07-04
+Source Type: Tutorial
+Relevance: High
+Confidence: Medium
+
+RAW_SIGNAL_LOG
+
+Signal: 2026年顶尖 AI 编程助手根据工作流分为 IDE (如 Cursor)、终端 (如 Claude Code、Aider)、云端异步 (如 Codex) 等不同类型.
+Source: Coursiv
+Why It May Matter: 明确了基于场景选择 Coding Agent 的趋势，不再是单一工具包打天下.
+Uncertainty: Low
+
+Signal: MCP 协议将在2026年7月28日发布自推出以来最大的更新，核心变化是转向无状态协议 (移除 sessions 和初始化握手)，并引入扩展框架、MCP Apps、Tasks 及更严格的授权控制.
+Source: WorkOS / Model Context Protocol Blog
+Why It May Matter: 这一改变将极大影响 MCP 服务器的部署方式和 Agent 的认证授权机制，开发者需要在7月底前完成迁移.
+Uncertainty: Low
+
+Signal: Gemini Enterprise Agent Platform 现在支持 Google Maps Grounding，提供 places (地点搜索) 和 routing (路线规划) 两种类型. 且 Gemini 2.5 Pro 等支持此特性.
+Source: Google Cloud Docs / DataCamp
+Why It May Matter: Agent 工作流现在能更精确地处理地理空间信息和实时路线，丰富了应用场景.
+Uncertainty: Low
+
+Signal: AI Studio 在2026年提供 Gemini 3.5 Flash 作为代码和 Agent 任务的默认模型，具备 1M token 上下文并在 Terminal-Bench 2.1 表现出色.
+Source: DataCamp
+Why It May Matter: 提示开发者生态中的模型基座正在快速迭代，针对终端 Agentic 任务的能力在持续强化.
+Uncertainty: Low
+
+NEXT_HANDOFF
+
+写给 H2 (Orient) 的输入提示:
+请重点分析 MCP 2026-07-28 无状态更新对现有 Agent 通信架构的影响，评估是否需要更新系统以适应新的身份验证和能力发现机制 (server/discover).
+研究 Google Maps Grounding 如何与我们的 Agent 工作流集成，特别是在处理涉及地理信息的任务时.
+分析云端异步运行 Coding Agent (如 Codex) 和本地终端执行 (如 Claude Code) 的权衡.
+
+哪些信号可能只是噪音:
+关于具体哪款 Coding Agent 更好 (如 Cursor vs 其它) 的评测带有主观色彩，可能随着时间推移快速变化，属于短期噪音.
+
+BOUNDARY_CHECK
+
+确认没有读取宿主仓库机制: YES
+确认没有读取 GitHub Actions: YES
+确认没有写入 horizon-cortex 之外的文件: YES


### PR DESCRIPTION
Added the H1 daily signal observation markdown file for 2026-07-04 tracking MCP, AI Agents, and Google Maps Grounding updates. Adheres to all requested constraints and NO_CHINESE_PERIODS rule.

---
*PR created automatically by Jules for task [8010290545863575291](https://jules.google.com/task/8010290545863575291) started by @lostlight530*