### PR TITLE
feat: add week 27 H3 weekly position decide

### DIFF
--- a/horizon-cortex/2026-W27-H3-position-decide.md
+++ b/horizon-cortex/2026-W27-H3-position-decide.md
@@ -1,0 +1,118 @@
+H3 Weekly Position Decide
+
+CORTEX_RUN_HEADER
+
+Cortex: horizon-cortex
+
+Host Repository: welcome-to-github
+
+Task ID: H3
+
+Cadence: Weekly
+
+Loop Stage: Decide
+
+Run Week: 2026-W27
+
+Agent: Jules
+
+Knowledge Source: This Week H1 / H2 + External Web + horizon-cortex local files
+
+Repository Inspection: NO
+
+GitHub Actions Inspection: NO
+
+Write Scope: horizon-cortex only
+
+Boundary Violation: NO
+
+INPUT_RECORD
+
+记录本周读取的 H1 和 H2 文件列表
+horizon-cortex/2026-07-01-H1-signal-observe.md
+horizon-cortex/2026-07-01-H2-horizon-orient.md
+horizon-cortex/2026-07-02-H1-signal-observe.md
+horizon-cortex/2026-07-02-H2-horizon-orient.md
+horizon-cortex/2026-07-03-H1-signal-observe.md
+horizon-cortex/2026-07-03-H2-horizon-orient.md
+horizon-cortex/2026-07-04-H1-signal-observe.md
+horizon-cortex/2026-07-04-H2-horizon-orient.md
+horizon-cortex/2026-07-05-H2-horizon-orient.md
+
+记录读取的历史 H3 / H4 / H6 文件列表
+horizon-cortex/sample-2026-W27-H3-position-decide.md
+horizon-cortex/sample-2026-W27-H4-narrative-act.md
+horizon-cortex/sample-2026-07-H5-signal-reflect.md
+horizon-cortex/sample-2026-07-H6-horizon-memorize.md
+
+记录联网验证的主题和来源
+"Model Context Protocol" stateless update July 2026 (来源 WorkOS, Model Context Protocol Blog)
+
+WEEKLY_SIGNAL_SYNTHESIS
+
+总结本周重复出现的信号
+MCP 生态和安全性是焦点，微软发布了 MCP 安全剧本，MCP 即将在 7 月 28 日进行重大的无状态架构更新
+
+总结本周新出现的信号
+MCP 将弃用 session 和初始化握手，转向无状态协议，引入新的身份验证机制和发现机制，这是自发布以来最大的架构更新
+
+总结本周被证伪或降级的信号
+关于哪种具体的 Coding Agent 更好属于短期噪音，重点应放在 Agent 工作流和底层标准的演进上
+
+DECISION_SET
+
+Decision 1
+
+Decision: 将 MCP 2026-07-28 的无状态更新和安全性作为下周核心关注方向
+
+Evidence: 微软发布的防御剧本以及 MCP 官方发布的 2026-07-28 候选版本说明
+
+Expected Value: 提前适应 MCP 无状态架构带来的身份验证和能力发现机制变化，确保生态兼容和安全合规
+
+Risk: 过度聚焦于协议底层实现细节而忽视顶层应用场景的演进
+
+Why Now: MCP 无状态更新是即将在七月底落地的强制性重大改变，必须尽早评估影响
+
+Decision 2
+
+Decision: 关注基于终端 (CLI) 和云端异步执行的多形态 Agent 工作流演进
+
+Evidence: Uno Platform 的开发者工具趋势和 Google AI Studio 中对终端任务模型的强化
+
+Expected Value: 探索适合当前开发心智模型的 Agent 交互形态，为后续工作流集成提供参考
+
+Risk: 各类终端工具标准尚未统一，可能投入精力在被快速淘汰的过度产品上
+
+Why Now: 工具形态正在从 Copilot 转向自主执行，需要明确未来的交互基座
+
+DO_NOT_PURSUME
+
+本周明确不追的方向
+不追逐具体的 Coding Agent 工具对比（如 Cursor 与其他工具的优劣比较）
+不追逐除 MCP 之外的处于早期概念阶段的 Agent 通信协议
+
+说明为什么不追
+工具排名具有较强主观性和时效性，容易成为噪音；新通信协议采纳率未得到验证，当前应聚焦已成事实标准的 MCP 重大更新
+
+HANDOFF_TO_H4
+
+把 H4 需要执行的 horizon-cortex 内部更新写清楚
+H4 需要在 horizon-cortex 内部撰写关于应对 MCP 2026-07-28 无状态更新的行动叙事
+H4 需要针对终端形态的 Agent 工作流在内部进行推演记录
+
+只能提出 horizon-cortex 内部更新
+上述行动必须仅在 horizon-cortex 内部生成对应的记录文档
+
+不得要求修改宿主仓库
+不修改任何宿主仓库的 README 和其他非 horizon-cortex 代码
+
+BOUNDARY_CHECK
+
+确认没有读取宿主仓库机制
+YES
+
+确认没有读取 GitHub Actions
+YES
+
+确认没有写入 horizon-cortex 之外的文件
+YES


### PR DESCRIPTION
Generates the H3 position decide output for week 27 based on H1 and H2 observations, along with search verification for MCP stateless update.

---
*PR created automatically by Jules for task [16867939315865235314](https://jules.google.com/task/16867939315865235314) started by @lostlight530*