### PR TITLE
fix: resolve github pages multiple artifacts error by disabling cancel-in-progress

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ permissions:
 
 concurrency:
   group: "pages"
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   GITHUB_DEPENDENCY_GRAPH_ENABLED: 'false'


### PR DESCRIPTION
This PR fixes the "Multiple artifacts" error encountered during GitHub Pages deployment.

1.  **Fixed Concurrency Issue:** Changed `cancel-in-progress: true` to `cancel-in-progress: false` in `.github/workflows/deploy.yml`. This prevents ongoing deployments from being abruptly canceled by new pushes, which is the primary cause of duplicate artifacts being generated for a single workflow run in `actions/deploy-pages`.
2.  **Triggered State Reset:** Included an empty commit (`chore: trigger empty commit to reset CI/CD artifact state`) to trigger a fresh deployment pipeline with the updated configuration, effectively clearing the race condition state and resolving the immediate blockage.

---
*PR created automatically by Jules for task [13488162569560846884](https://jules.google.com/task/13488162569560846884) started by @lostlight530*