### PR TITLE
feat(horizon-cortex): add weekly H4 narrative act for 2026-W27

### DIFF
--- a/horizon-cortex/2026-W27-H4-narrative-act.md
+++ b/horizon-cortex/2026-W27-H4-narrative-act.md
@@ -1,0 +1,96 @@
+CORTEX_RUN_HEADER
+
+Cortex: horizon-cortex
+
+Host Repository: welcome-to-github
+
+Task ID: H4
+
+Cadence: Weekly
+
+Loop Stage: Act
+
+Run Week: 2026-W27
+
+Agent: Jules
+
+Knowledge Source: H3 decision + External Web + horizon-cortex local files
+
+Repository Inspection: NO
+
+GitHub Actions Inspection: NO
+
+Write Scope: horizon-cortex only
+
+Boundary Violation: NO
+
+INPUT_RECORD
+
+记录读取的 H3 文件路径
+horizon-cortex/2026-W27-H3-position-decide.md
+
+记录读取的辅助 H1 / H2 文件路径
+horizon-cortex/2026-07-01-H1-signal-observe.md
+horizon-cortex/2026-07-01-H2-horizon-orient.md
+
+记录联网复核来源
+Google Search: "Model Context Protocol" stateless update July 2026
+- Akamai Security Research: "The New MCP Specification: What Security Teams Must Prepare For"
+- WorkOS Blog: "The biggest MCP spec update ships July 28"
+- Model Context Protocol Blog: "The 2026-07-28 MCP Specification Release Candidate"
+
+ACTION_RECORD
+
+Action 1
+Action: 更新内部知识库关注点, 聚焦 MCP 无状态架构 (Update internal knowledge base focus to MCP stateless architecture)
+Reason: H3 decision prioritized the MCP stateless update scheduled for 2026-07-28 and its security implications.
+Source Decision: Decision 1 - "将 MCP 2026-07-28 的无状态更新和安全性作为下周核心关注方向"
+Expected Effect: Future intelligence gathering will proactively capture details regarding MCP migration strategies, authentication changes, and security boundaries.
+Risk Reduced: Reduces the risk of missing critical infrastructure shifts and falling behind in MCP compliance and security.
+No Host Repository Change: YES
+
+Action 2
+Action: 记录终端形态 Agent 工作流的演进推演 (Record deductions on terminal-based Agent workflow evolution)
+Reason: H3 decision emphasized tracking multi-format Agent workflows, specifically focusing on terminal (CLI) and cloud-based asynchronous execution.
+Source Decision: Decision 2 - "关注基于终端 (CLI) 和云端异步执行的多形态 Agent 工作流演进"
+Expected Effect: Establishes a foundational understanding of the transition from Copilot-style tools to autonomous execution tools within horizon-cortex records.
+Risk Reduced: Mitigates the risk of adopting transitional or obsolete Agent interaction paradigms.
+No Host Repository Change: YES
+
+NEXT_WEEK_OPERATING_NOTES
+
+下周重点观察主题 (Key observation topics for next week)
+- MCP 2026-07-28 无状态架构更新的详细规范, 特别是身份验证机制的变化
+- MCP 安全生态系统, 包括企业级防御指南和相关漏洞 (如 Agentjacking)
+- 基于终端 (CLI) 的 Agent 工具链的发展和生态集成
+
+下周需要避免的误判 (Misjudgments to avoid next week)
+- 避免过度关注具体的 Coding Agent 产品功能对比排名, 因为这些易变且主观
+- 避免投入精力在非主流的, 未经验证的 Agent 通信协议上, 维持对 MCP 作为事实标准的关注
+
+下周需要继续验证的来源类型 (Source types to continue verifying next week)
+- MCP 官方博客和维护者更新
+- 权威安全机构 (如 NSA) 及头部安全厂商的安全指南和漏洞报告
+- 开发者社区和主要云服务商关于 MCP 迁移实践的讨论
+
+ACTION_LIMITS
+
+明确说明本次没有修改宿主仓库
+本次操作仅限于创建 horizon-cortex 内部的 H4 记录文件, 绝对没有修改 welcome-to-github 仓库的任何外部文件或代码
+
+明确说明本次没有修改 GitHub Actions
+本次操作绝对没有读取或修改任何 .github 目录下的 GitHub Actions 配置
+
+明确说明本次没有创建非周期文件
+本次仅创建了符合 YYYY-WXX 命名规范的 H4 周期性记录文件, 没有创建任何静态规则文件或其他格式的文档
+
+BOUNDARY_CHECK
+
+确认没有读取宿主仓库机制
+YES
+
+确认没有读取 GitHub Actions
+YES
+
+确认没有写入 horizon-cortex 之外的文件
+YES


### PR DESCRIPTION
This PR generates the `2026-W27-H4-narrative-act.md` file according to the strict weekly requirements. It reads the previous H1/H2 and H3 decisions, verifies the validity of the MCP stateless update topic externally, and translates the decisions into the required action format without modifying host repository code or GitHub actions.

---
*PR created automatically by Jules for task [15442194846667614687](https://jules.google.com/task/15442194846667614687) started by @lostlight530*