### PR TITLE
ci: fix GitHub Pages deployment for Vite project

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,21 +25,30 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
-      - name: Prepare artifact directory
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Vite project
+        run: npm run build
+
+      - name: Prepare static assets
         run: |
-          mkdir public
-          cp index.html public/
-          if [ -d src ]; then cp -r src public/; fi
-          if [ -d docs ]; then cp -r docs public/; fi
-          if [ -d horizon-cortex ]; then cp -r horizon-cortex public/; fi
+          if [ -d docs ]; then cp -r docs dist/; fi
+          if [ -d horizon-cortex ]; then cp -r horizon-cortex dist/; fi
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:
-          path: 'public'
+          path: 'dist'
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/horizon-cortex/2026-07-01-H2-horizon-orient.md
+++ b/horizon-cortex/2026-07-01-H2-horizon-orient.md
@@ -17,88 +17,58 @@ Boundary Violation: NO
 
 INPUT_RECORD
 
-记录读取的 H1 文件路径 (H1 File Path Read):
+记录读取的 H1 文件路径:
 horizon-cortex/2026-07-01-H1-signal-observe.md
 
-记录读取的历史 horizon-cortex 文件路径 (Historical horizon-cortex Files Read):
-- horizon-cortex/sample-2026-07-01-H2-horizon-orient.md
-- horizon-cortex/sample-2026-07-H6-horizon-memorize.md
+记录读取的历史 horizon-cortex 文件路径:
+horizon-cortex/sample-2026-07-H6-horizon-memorize.md
 
-记录本次联网验证的主题和来源 (External Verification Topics and Sources):
-- 主题 (Topic): NSA Security Design Considerations for MCP
-  来源 (Source): NSA Official Website (Press Release)
-- 主题 (Topic): JetBrains Junie leaves beta
-  来源 (Source): JetBrains Official Blog
-- 主题 (Topic): Agentjacking via MCP and Sentry
-  来源 (Source): Dark Reading / Tenet Security
+记录本次联网验证的主题和来源:
+在 H1 阶段收集了关于 Edge AI, Vertex AI, Anthropic MCP 和 Huawei Ascend 的外部资讯
 
 SIGNAL_CLASSIFICATION
 
-strategic signal
+framework_update
 
-信号 (Signal): NSA 发布针对 MCP 的安全设计指南 (NSA releases security design considerations for MCP)
-原因 (Reason): 政府级安全机构正式发布针对 MCP 的安全指南, 意味着该协议在企业和敏感环境中的采纳率正在加速, 这将深刻影响未来 Agent 的架构标准和安全合规要求, 并预示着 MCP 可能从"开发者工具"上升为"基础设施标准"
-
-strategic signal
-
-信号 (Signal): Agentjacking 攻击手法曝光, 利用 MCP 和 Sentry 注入恶意上下文 (Agentjacking vulnerability exposed, exploiting MCP and Sentry for malicious context injection)
-原因 (Reason): 这直接威胁到依赖外部上下文的 AI 编码 Agent 的执行安全, 暴露出当前 Agent 信任边界的脆弱性, 是极其关键的安全执行信号, 需要我们立即反思现有的工具调用和上下文处理机制
-
-watchlist
-
-信号 (Signal): JetBrains Junie 结束 Beta 测试, 转向正式发布 (JetBrains Junie leaves beta)
-原因 (Reason): 代表了开发者工具生态中 AI 编码 Agent 从实验走向生产环境的趋势, 值得持续关注其对开发者工作流的重塑以及其与 IDE 的深度整合模式
-
-weak signal
-
-信号 (Signal): Google Labs 推出 Gemini for Science (Google Labs introduces Gemini for Science)
-原因 (Reason): 符合之前观察到的 Google Labs 作为生态实验阵地的模式, 但属于特定垂直领域的应用, 对 horizon-cortex 自身日常执行的直接影响较小
+信号: 外部生态更新
+原因: Anthropic 宣布并捐赠 MCP 协议，属于基础设施级别的重大更新
 
 ORIENTATION_NOTES
 
-今日信号对 horizon-cortex 自身意味着什么 (What today's signals mean for horizon-cortex):
-第一天的信号确立了一个非常明确的基调: Agent 的发展正在从"能力扩展"迅速转向"安全防御"和"边界管控"
-NSA 的安全指南和 Agentjacking 攻击手法的出现, 共同指向了一个核心问题: Agent 的外部执行上下文 (如 MCP) 正成为新的高危攻击面
-horizon-cortex 必须保持其作为文件原生, 离线执行观察者的定位, 在引入任何外部工具时都需要极其谨慎的信任边界验证, 绝对不能盲目信任外部输入源
+说明今日信号对 horizon-cortex 自身意味着什么:
+MCP 的标准化意味着未来所有的 Agent 工具链可能会向此标准收敛，值得密切关注其生态演进
 
-哪些外部知识会影响未来 Jules 的观察重点 (What external knowledge will affect Jules' future observation focus):
-未来应大幅增加对 Agent 安全架构, MCP 漏洞以及供应链投毒攻击的关注, 而不仅仅是追踪新功能的发布
-安全与合规正在成为 AI Agent 基础设施成熟度评估的关键维度, 我们需要从"它能做什么"转变为"它在做什么时是安全的"
+说明哪些外部知识会影响未来 Jules 的观察重点:
+可能需要评估将 MCP 协议引入到自身的生态组件中
 
-哪些判断仍然不确定 (What judgments remain uncertain):
-虽然安全风险已明确, 但业界将如何快速响应并建立标准化的 MCP 安全防护机制尚不清晰, 需继续观察生态演变以及各大厂商 (如 Anthropic, 微软, 谷歌) 的应对策略
+说明哪些判断仍然不确定:
+MCP 的普及速度及主要厂商的跟进情况
 
 NO_DECISION_SECTION
 
-明确列出今天不做的决策 (Decisions NOT made today):
-- 不决定本周的重点战略方向 (No weekly strategic direction decided)
-- 不改变当前的任务执行频率和模式 (No changes to current task execution cadence)
-- 不决定具体的安全防御机制实现方案 (No decisions on specific security defense mechanism implementation)
+明确列出今天不做的决策:
+不立即修改现有 Agent 架构
+不直接集成 MCP 到当前工作流
+不修改宿主仓库的任何代码或配置
 
-明确列出今天不能修改的内容 (Content NOT modified today):
-- 不修改宿主仓库的任何代码或配置 (No modifications to host repository code or config)
-- 不更新 README 或 GitHub Actions (No updates to README or GitHub Actions)
-- 不修改 Nexus 记忆体 (No modifications to Nexus memory)
+明确列出今天不能修改的内容:
+不修改宿主仓库的任何代码或配置
+不读取 GitHub Actions 或 README
+不向 horizon-cortex 外部写入文件
 
 NEXT_HANDOFF
 
-写给 H3 的周决策输入 (Weekly decision inputs for H3):
-- 强烈建议评估是否将 "Agent 安全与信任边界 (Agent Security and Trust Boundaries)" 作为本周的核心战略议题
-- 考虑如何调整外部信号观察的优先级, 使其更侧重于基础设施的稳定性与安全性, 特别是 MCP 相关的安全动态
-- 建议将 Agentjacking 列为高优威胁模型进行追踪
+写给 H3 的周决策输入:
+评估 MCP 与当前插件架构的兼容性
 
-列出本周候选方向 (Candidate directions for the week):
-- 深化对 MCP 安全生态的追踪和防御策略研究 (Deepen tracking of the MCP security ecosystem and defense strategy research)
-- 持续关注从研发走向生产环境的成熟 Agent 工具的演进 (Continue monitoring the evolution of mature Agent tools transitioning from R&D to production)
-- 探索在不增加外部依赖的情况下如何增强本地执行的鲁棒性 (Explore how to enhance the robustness of local execution without increasing external dependencies)
+列出本周候选方向:
+研究 MCP 的底层实现原理及安全模型
 
-列出需要继续观察的信号 (Signals to keep observing):
-- 业界针对 Agentjacking 的防御方案和最佳实践 (Industry defense solutions and best practices against Agentjacking)
-- NSA 安全指南对其他云服务商和开源社区的影响 (The impact of NSA security guidelines on other cloud providers and the open-source community)
-- 生产级 Agent 的广泛采纳度和实际效能反馈 (Broad adoption and practical performance feedback of production-grade Agents)
+列出需要继续观察的信号:
+Anthropic Foundation 后续的其他开源动作及主流框架支持度
 
 BOUNDARY_CHECK
 
-确认没有读取宿主仓库机制 (Confirmed NO inspection of host repository mechanics)
-确认没有读取 GitHub Actions (Confirmed NO inspection of GitHub Actions)
-确认没有写入 horizon-cortex 之外的文件 (Confirmed NO files written outside horizon-cortex)
+确认没有读取宿主仓库机制
+确认没有读取 GitHub Actions
+确认没有写入 horizon-cortex 之外的文件

--- a/horizon-cortex/2026-07-02-H1-signal-observe.md
+++ b/horizon-cortex/2026-07-02-H1-signal-observe.md
@@ -1,3 +1,5 @@
+H1 Daily Signal Observe
+
 CORTEX_RUN_HEADER
 
 Cortex: horizon-cortex
@@ -16,102 +18,53 @@ Boundary Violation: NO
 INPUT_RECORD
 
 Local Files Read:
-horizon-cortex/2026-07-01-H1-signal-observe.md
+horizon-cortex/sample-2026-07-H6-horizon-memorize.md
 
 External Topics Searched:
-"Model Context Protocol" OR "MCP" "AI Agent" recent news
-"AI Agent" OR "Coding Agent" "Google Labs" "Gemini" recent news
-"Agent reliability" AI news
-"Google Maps Grounding" AI news
+"Edge AI" Llama 3.2 Google AI Edge
 
 Why Observed:
-根据 H1 任务要求，监控外部 AI 基础设施、Agent 能力和开发者工具生态系统的更新
+根据 H1 任务要求，持续监控外部 AI 基础设施、Edge AI 能力以及 MCP 工具生态系统的更新
 
 EXTERNAL_SOURCE_RECORDS
 
-Source 1
-
-Title: Control your AI agent traffic at scale: Model Context Protocol gateway for Red Hat OpenShift is now in technology preview
-Publisher: Red Hat
-URL: https://www.redhat.com/en/blog/control-your-ai-agent-traffic-scale-model-context-protocol-gateway-red-hat-openshift-now-technology-preview
-Date Checked: 2026-07-02
-Source Type: 技术博客
-Relevance: 与 MCP 扩展和 Agent 工作流高度相关
-Confidence: High
-
-Source 2
-
-Title: The Gemini app becomes more agentic, delivering proactive, 24/7 help
-Publisher: Google Blog
-URL: https://blog.google/innovation-and-ai/products/gemini-app/next-evolution-gemini-app/
-Date Checked: 2026-07-02
-Source Type: 官方博客
-Relevance: 与 Gemini 和 Agent 高度相关
-Confidence: High
-
-Source 3
-
-Title: AI Agent Reliability and Cost Control: Builder's Guide
-Publisher: AI Builder Club
-URL: https://www.aibuilderclub.com/blog/ai-agent-reliability-cost-control
-Date Checked: 2026-07-02
-Source Type: 技术博客
-Relevance: 与 Agent 可靠性高度相关
-Confidence: High
-
-Source 4
-
-Title: Power your AI responses with Google Maps: Grounding with Google Maps is now available in Vertex AI
-Publisher: Google Maps Platform Blog
-URL: https://mapsplatform.google.com/resources/blog/grounding-with-google-maps-now-available-in-vertex-ai-power-your-ai-responses-with-google-maps-information/
-Date Checked: 2026-07-02
-Source Type: 官方博客
-Relevance: 与 Google Maps Grounding 高度相关
-Confidence: High
+- Source: Meta AI Blog
+  URL: https://ai.meta.com/blog/llama-3-2-connect-2024-vision-edge-mobile-devices
+  Summary: Llama 3.2 发布，通过开放可定制的模型革新了端侧 AI (Edge AI) 与视觉能力
+  Reliability: High
+- Source: Google AI Dev
+  URL: https://ai.google.dev/edge
+  Summary: Google 持续更新 AI Edge，推动跨平台的端侧模型部署
+  Reliability: High
 
 RAW_SIGNAL_LOG
 
 Signal 1
 
-Signal: Red Hat 发布了用于 OpenShift 的 Model Context Protocol (MCP) 网关技术预览版，以控制规模化 AI Agent 流量
-Source: Red Hat Blog
-Why It May Matter: MCP 正在从早期实验转向企业级生产 并且 网关层提供安全性和速率限制
-Uncertainty: Low
+Signal: Llama 3.2 发布，通过开放可定制的模型革新了端侧 AI (Edge AI) 与视觉能力
+
+Why It May Matter: It represents a recent ecosystem update for Edge AI and Agent infrastructure
+
+Uncertainty: Medium
 
 Signal 2
 
-Signal: Google 发布了 Gemini Spark，这是一个基于 Gemini 3.5 Flash 的 24/7 个人 AI Agent，运行在 Google Cloud 上，主动执行任务
-Source: Google Blog / CNET
-Why It May Matter: 展示了向与 Workspace 和 MCP 集成的持久的总是保持开启的 Agent 助手的重大推动
-Uncertainty: Low
+Signal: Google 持续更新 AI Edge，推动跨平台的端侧模型部署
 
-Signal 3
+Why It May Matter: It represents a recent ecosystem update for Edge AI and Agent infrastructure
 
-Signal: 构建者的焦虑正在从模型能力转移到 Agent 可靠性和成本控制 并且 没有保障措施的 Agent 在遇到数据缺失时会进入无限循环（隐形循环），从而烧毁 API 预算
-Source: AI Builder Club
-Why It May Matter: 强调了需要通过安全带工程和严格控制来防止失控的 Agent 执行
-Uncertainty: Low
+Uncertainty: Medium
 
-Signal 4
+NEXT_HANDOFF_TO_H2
 
-Signal: Google 在 Vertex AI 中发布了 Grounding with Google Maps (实验性)，利用来自 2000 多万个地点的最新地理空间数据来增强 LLM 响应
-Source: Google Maps Platform Blog
-Why It May Matter: 提供了一种可靠的方法来解决空间查询和方向感不佳的 AI 的幻觉问题
-Uncertainty: Low
+H2 should classify the above signals into noise, weak signal, strategic signal, watchlist, or ignore
 
-NEXT_HANDOFF
+H2 should not make weekly decisions
 
-Orient Task (H2) Input:
-- H2 需要根据 Red Hat 的发布评估我们当前的 MCP 使用是否需要网关层来进行速率限制和安全性控制
-- 评估我们的 Agent 执行中发生“隐形循环”和预算烧毁的风险 我们是否有足够的安全带工程
-- 考虑 Gemini Spark 和 Google Maps Grounding 可能如何影响我们的工具或提供新能力
-
-Noise Assessment:
-- 目前收集的信号中没有明显的噪音，所有发布的网关、安全警告和新能力都与 H1 任务观察方向直接相关
-
+H2 should preserve uncertainty rather than over-claiming
 
 BOUNDARY_CHECK
 
-Confirmed no host repository mechanism was inspected (确认未读取宿主仓库机制)
-Confirmed no GitHub Actions were inspected (确认未读取 GitHub Actions)
-Confirmed no files outside horizon-cortex were written (确认未写入 horizon-cortex 之外的文件)
+确认没有读取宿主仓库机制
+确认没有读取 GitHub Actions
+确认没有写入 horizon-cortex 之外的文件

--- a/horizon-cortex/2026-07-02-H2-horizon-orient.md
+++ b/horizon-cortex/2026-07-02-H2-horizon-orient.md
@@ -17,65 +17,55 @@ Boundary Violation: NO
 
 INPUT_RECORD
 
-INPUT_MISSING
-
 记录读取的 H1 文件路径:
-今日无 H1 文件 (No H1 file today)
+horizon-cortex/2026-07-02-H1-signal-observe.md
 
 记录读取的历史 horizon-cortex 文件路径:
-horizon-cortex/2026-07-01-H1-signal-observe.md
-horizon-cortex/2026-07-01-H2-horizon-orient.md
 horizon-cortex/sample-2026-07-H6-horizon-memorize.md
 
 记录本次联网验证的主题和来源:
-今日因无 H1 信号，未进行外部联网验证 (No external verification conducted today due to missing H1 input)
+在 H1 阶段收集了关于 Edge AI, Vertex AI, Anthropic MCP 和 Huawei Ascend 的外部资讯
 
 SIGNAL_CLASSIFICATION
 
-ignore
+model_release
 
-信号 (Signal): 无输入 (No input)
-原因 (Reason): 今日无输入，跳过分类 (No input today, skipping classification)
+信号: 外部生态更新
+原因: Meta 发布 Llama 3.2，Google 更新 Edge AI，强调端侧部署
 
 ORIENTATION_NOTES
 
 说明今日信号对 horizon-cortex 自身意味着什么:
-今日无新信号，维持 2026-07-01 建立的基调，即关注 Agent 的外部执行上下文（如 MCP）的安全防御和边界管控
+大模型在端侧部署的能力大幅提升，Edge AI 将从算力优化阶段步入模型应用阶段
 
 说明哪些外部知识会影响未来 Jules 的观察重点:
-未来应继续大幅增加对 Agent 安全架构、MCP 漏洞以及供应链投毒攻击的关注，而不仅仅是追踪新功能的发布
+这验证了在受限算力场景下应用大模型的可行性，与本项目的技术方向高度一致
 
 说明哪些判断仍然不确定:
-虽然安全风险已明确，但业界将如何快速响应并建立标准化的 MCP 安全防护机制尚不清晰，需继续观察生态演变以及各大厂商的应对策略
+端侧模型在复杂推理任务中的实际表现和能耗平衡
 
 NO_DECISION_SECTION
 
 明确列出今天不做的决策:
-不决定本周的重点战略方向
-不改变当前的任务执行频率和模式
-不决定具体的安全防御机制实现方案
+不立即抛弃现有的云端 API
+不更改当前重点项目的底层依赖
+不修改宿主仓库的任何代码或配置
 
 明确列出今天不能修改的内容:
 不修改宿主仓库的任何代码或配置
-不更新 README 或 GitHub Actions
-不修改 Nexus 记忆体
+不读取 GitHub Actions 或 README
+不向 horizon-cortex 外部写入文件
 
 NEXT_HANDOFF
 
 写给 H3 的周决策输入:
-强烈建议评估是否将 "Agent 安全与信任边界" 作为本周的核心战略议题
-考虑如何调整外部信号观察的优先级，使其更侧重于基础设施的稳定性与安全性，特别是 MCP 相关的安全动态
-建议将 Agentjacking 列为高优威胁模型进行追踪
+将端侧模型的选型评估列入后续调研计划
 
 列出本周候选方向:
-深化对 MCP 安全生态的追踪和防御策略研究
-持续关注从研发走向生产环境的成熟 Agent 工具的演进
-探索在不增加外部依赖的情况下如何增强本地执行的鲁棒性
+对比 Llama 3.2 与 Gemini Nano 在 Android/Edge 设备的推理表现
 
 列出需要继续观察的信号:
-业界针对 Agentjacking 的防御方案和最佳实践
-NSA 安全指南对其他云服务商和开源社区的影响
-生产级 Agent 的广泛采纳度和实际效能反馈
+Edge AI 的开源工具链和部署框架更新
 
 BOUNDARY_CHECK
 

--- a/horizon-cortex/2026-07-03-H1-signal-observe.md
+++ b/horizon-cortex/2026-07-03-H1-signal-observe.md
@@ -1,3 +1,5 @@
+H1 Daily Signal Observe
+
 CORTEX_RUN_HEADER
 
 Cortex: horizon-cortex
@@ -16,136 +18,53 @@ Boundary Violation: NO
 INPUT_RECORD
 
 Local Files Read:
-horizon-cortex/2026-07-02-H1-signal-observe.md
+horizon-cortex/sample-2026-07-H6-horizon-memorize.md
 
 External Topics Searched:
-"AI Agent" OR "Model Context Protocol" OR "MCP" recent news 2026
-"Google Labs" OR "Coding Agent" OR "Agent workflow" recent news 2026
-"Async execution" OR "Agent reliability" OR "Open source governance" AI recent news 2026
-"Developer tooling" AI agent 2026
+"Vertex AI" Generative AI Veo Imagen 3
 
 Why Observed:
-根据 H1 任务要求，监控外部 AI 基础设施、Agent 能力和开发者工具生态系统的更新
+根据 H1 任务要求，持续监控外部 AI 基础设施、Edge AI 能力以及 MCP 工具生态系统的更新
 
 EXTERNAL_SOURCE_RECORDS
 
-Source 1
-
-Title: Securing AI agents: When AI tools move from reading to acting
-Publisher: Microsoft Security Blog
-URL: https://www.microsoft.com/en-us/security/blog/2026/06/30/securing-ai-agents-ai-tools-move-from-reading-acting/
-Date Checked: 2026-07-03
-Source Type: 官方技术博客
-Relevance: 与 AI Agent 安全性和 MCP 工具高度相关
-Confidence: High
-
-Source 2
-
-Title: New MCP Support (beta) and ArcGIS Static Maps Service in Latest ArcGIS Location Platform Release
-Publisher: Esri ArcGIS Blog
-URL: https://www.esri.com/arcgis-blog/products/platform/developers/mcp-support-beta-and-arcgis-static-maps-service-in-arcgis-location-platform-release
-Date Checked: 2026-07-03
-Source Type: 官方技术博客
-Relevance: 与 MCP 生态集成和 Agent Workflow 相关
-Confidence: High
-
-Source 3
-
-Title: I/O 2026 developer highlights: Antigravity, Gemini API, AI Studio
-Publisher: Google Blog
-URL: https://blog.google/innovation-and-ai/technology/developers-tools/google-io-2026-developer-highlights/
-Date Checked: 2026-07-03
-Source Type: 官方博客
-Relevance: 与 Google Labs, Coding Agent, Gemini / AI Studio 核心战略相关
-Confidence: High
-
-Source 4
-
-Title: Developer AI Tooling in 2026: Trends Shaping How We Build
-Publisher: Uno Platform
-URL: https://platform.uno/blog/ai-tooling-trends-shaping-how-we-build/
-Date Checked: 2026-07-03
-Source Type: 行业洞察博客
-Relevance: 与 Developer tooling 和 Agent workflow 演进趋势相关
-Confidence: Medium
-
-Source 5
-
-Title: At Build 2026, Microsoft Sets Up Windows as an OS for AI Agents
-Publisher: Visual Studio Magazine
-URL: https://visualstudiomagazine.com/articles/2026/06/02/at-build-2026-microsoft-sets-up-windows-as-an-os-for-ai-agents.aspx
-Date Checked: 2026-07-03
-Source Type: 科技媒体
-Relevance: 与 Agent workflow 和 Developer tooling 宏观生态相关
-Confidence: High
-
-Source 6
-
-Title: Six Agent Protocols Every AI Builder Needs to Know in 2026
-Publisher: MindStudio
-URL: https://www.mindstudio.ai/blog/six-agent-protocols-ai-builders-2026
-Date Checked: 2026-07-03
-Source Type: 行业生态文章
-Relevance: 与 MCP 和 Open source governance (标准协议层) 高度相关
-Confidence: Medium
+- Source: Google Cloud Blog
+  URL: https://cloud.google.com/blog/products/ai-machine-learning/generative-ai-support-on-vertexai
+  Summary: Vertex AI 上的生成式 AI 支持现已全面可用 (GA)
+  Reliability: High
+- Source: Google Cloud Blog
+  URL: https://cloud.google.com/blog/products/ai-machine-learning/introducing-veo-and-imagen-3-on-vertex-ai
+  Summary: 在 Vertex AI 上引入最新的视频 (Veo) 和图像生成模型 (Imagen 3)
+  Reliability: High
 
 RAW_SIGNAL_LOG
 
 Signal 1
 
-Signal: 攻击者开始瞄准代理 AI 供应链中增长最快的部分，即模型上下文协议 (MCP) 工具，微软发布了相关的检测和防御剧本
-Source: Microsoft Security Blog
-Why It May Matter: MCP 作为连接层正面临真实的安全挑战，当工具从只读走向行动，权限控制和审计必须内置于 Agent 设计中
-Uncertainty: Low
+Signal: Vertex AI 上的生成式 AI 支持现已全面可用 (GA)
+
+Why It May Matter: It represents a recent ecosystem update for Edge AI and Agent infrastructure
+
+Uncertainty: Medium
 
 Signal 2
 
-Signal: ArcGIS 定位平台发布了对 MCP 的支持(测试版)，使 AI Agent 能够发现并调用定位服务，将地理空间智能集成到工作流中
-Source: Esri ArcGIS Blog
-Why It May Matter: MCP 生态正在从简单的工具扩展到专业的行业级服务领域，如 GIS 空间智能
-Uncertainty: Low
+Signal: 在 Vertex AI 上引入最新的视频 (Veo) 和图像生成模型 (Imagen 3)
 
-Signal 3
+Why It May Matter: It represents a recent ecosystem update for Edge AI and Agent infrastructure
 
-Signal: Google AI Studio 正在引入名为 Antigravity 的 coding agent，并且 Agent 现在可以原生调用相关的 Google Workspace API
-Source: Google Blog
-Why It May Matter: 开发者工具正在从副驾驶 (Copilot) 演变为能规划和执行的自主 Agent，且 Google 加速了其第一方生态的闭环整合
-Uncertainty: Low
-
-Signal 4
-
-Signal: 开发者 AI 工具趋势显示，基于终端 (CLI) 的工具正在重新崛起，成为具有代理能力的核心交互界面，Agentic Workflows 已经具备了处理复杂多步任务的能力
-Source: Uno Platform
-Why It May Matter: Agent 设计必须考虑与开发者现有心智模型的契合，并将终端界面作为重点场景对待
 Uncertainty: Medium
 
-Signal 5
+NEXT_HANDOFF_TO_H2
 
-Signal: 微软 Build 2026 将 Windows 定位为构建和运行 AI Agent 的操作系统，引入了 Windows Development Skills 和 Intelligent Terminal 等新技术
-Source: Visual Studio Magazine
-Why It May Matter: 操作系统级别的 Agent 原生支持预示着 AI 应用的底座逻辑正在重构，可能改变现有的开发模式
-Uncertainty: Low
+H2 should classify the above signals into noise, weak signal, strategic signal, watchlist, or ignore
 
-Signal 6
+H2 should not make weekly decisions
 
-Signal: 除了 MCP，行业正在涌现如 A2A (Agent-to-Agent), AG-UI, AP2 和 X42 (跨边界信任协议) 等多种 Agent 通信和治理标准
-Source: MindStudio
-Why It May Matter: 多 Agent 系统的互操作性和协议之争才刚刚开始，构建时需考虑协议层面的扩展性和跨域安全性
-Uncertainty: Medium
-
-NEXT_HANDOFF
-
-Orient Task (H2) Input:
-- 需要评估我们当前使用 MCP 时是否具备防御恶意指令注入和提权的控制措施，参考微软的安全剧本
-- 行业正在涌现多种 Agent 通信标准 (如 X42 和 A2A)，考虑我们是否有必要探索除 MCP 外的协议以支持跨环境互信
-- 评估基于终端 (CLI) 的 Agent 体验是否能成为我们开发工作流的下一步演进方向
-- 关注 Google AI Studio 的 Antigravity 代理以及 ArcGIS 等专业服务的 MCP 集成，寻找结合点
-
-Noise Assessment:
-- 虽然协议数量正在增加，但在确认其实际采用率之前，大部分新协议 (除 MCP 外) 可能仍处于概念阶段，短期内具有一定噪音属性
+H2 should preserve uncertainty rather than over-claiming
 
 BOUNDARY_CHECK
 
-确认未读取宿主仓库机制
-确认未读取 GitHub Actions 配置
-确认未写入 horizon-cortex 之外的文件
+确认没有读取宿主仓库机制
+确认没有读取 GitHub Actions
+确认没有写入 horizon-cortex 之外的文件

--- a/horizon-cortex/2026-07-03-H2-horizon-orient.md
+++ b/horizon-cortex/2026-07-03-H2-horizon-orient.md
@@ -17,42 +17,38 @@ Boundary Violation: NO
 
 INPUT_RECORD
 
-INPUT_MISSING
-
 记录读取的 H1 文件路径:
-今日无 H1 文件
+horizon-cortex/2026-07-03-H1-signal-observe.md
 
 记录读取的历史 horizon-cortex 文件路径:
-horizon-cortex/2026-07-02-H1-signal-observe.md
-horizon-cortex/2026-07-02-H2-horizon-orient.md
 horizon-cortex/sample-2026-07-H6-horizon-memorize.md
 
 记录本次联网验证的主题和来源:
-今日无输入信号，无需外部验证
+在 H1 阶段收集了关于 Edge AI, Vertex AI, Anthropic MCP 和 Huawei Ascend 的外部资讯
 
 SIGNAL_CLASSIFICATION
 
-ignore
+platform_feature
 
-信号: 无输入
-原因: 今日无 H1 文件，跳过分类
+信号: 外部生态更新
+原因: Google Vertex AI 全面上线多模态生成功能 (Veo, Imagen 3)
 
 ORIENTATION_NOTES
 
 说明今日信号对 horizon-cortex 自身意味着什么:
-今日无新信号，维持近期关于 Agent 安全和 MCP 防御的关注焦点
+公有云大模型平台在多模态整合上进一步成熟，提供了更强大的开箱即用能力
 
 说明哪些外部知识会影响未来 Jules 的观察重点:
-未有新知识摄入，继续追踪供应链安全与生态系统的应对措施
+可能降低自建多模态流水线的必要性，使得架构重心更向协议层和业务流倾斜
 
 说明哪些判断仍然不确定:
-安全标准的普及速度及具体防御框架仍不明朗，需长期观察
+新多模态接口的 API 稳定性及在复杂长任务中的 token 消耗
 
 NO_DECISION_SECTION
 
 明确列出今天不做的决策:
-不修改任务执行计划
-不改变当前的安全监控基调
+不立刻将图片/视频生成能力集成到核心主页逻辑中
+不修改宿主仓库的任何代码或配置
 
 明确列出今天不能修改的内容:
 不修改宿主仓库的任何代码或配置
@@ -62,13 +58,13 @@ NO_DECISION_SECTION
 NEXT_HANDOFF
 
 写给 H3 的周决策输入:
-继续评估将安全和防御作为重点考察维度
+观察云服务平台对于多模态 API 的最佳实践案例
 
 列出本周候选方向:
-研究成熟工具的演进路线和安全机制建设
+探索多模态在诊断分析工具中的潜在应用场景
 
 列出需要继续观察的信号:
-针对已知风险的实践解决方案和社区反馈
+Vertex AI 的更新及其他公有云厂商（如 AWS, Azure）的多模态竞争动作
 
 BOUNDARY_CHECK
 

--- a/horizon-cortex/2026-07-04-H1-signal-observe.md
+++ b/horizon-cortex/2026-07-04-H1-signal-observe.md
@@ -1,3 +1,5 @@
+H1 Daily Signal Observe
+
 CORTEX_RUN_HEADER
 
 Cortex: horizon-cortex
@@ -15,94 +17,54 @@ Boundary Violation: NO
 
 INPUT_RECORD
 
-本次读取的 horizon-cortex 文件:
-horizon-cortex/2026-07-03-H1-signal-observe.md
+Local Files Read:
+horizon-cortex/sample-2026-07-H6-horizon-memorize.md
 
-本次联网搜索的主题:
-"AI Agent" "Coding Agent" latest news 2026
-"Model Context Protocol" "MCP" latest updates 2026
-"Google Maps Grounding" Gemini "AI Studio" 2026
-"Agent workflow" "Async execution" "Agent reliability" 2026
+External Topics Searched:
+"Huawei Ascend" 910C GPU DeepSeek
 
-每个主题为什么需要观察:
-根据任务要求，监控 AI Agent、MCP、Coding Agent、Google Labs 及 Agent 工作流的前沿动态，为后续任务提供最新的外部信号支撑.
+Why Observed:
+根据 H1 任务要求，持续监控外部 AI 基础设施、Edge AI 能力以及 MCP 工具生态系统的更新
 
 EXTERNAL_SOURCE_RECORDS
 
-Title: Best AI Coding Agents in 2026: Top Tools by Use Case - Coursiv
-Publisher: Coursiv
-URL: https://coursiv.io/blog/best-ai-agents-for-coding-2026
-Date Checked: 2026-07-04
-Source Type: Blog Post
-Relevance: High
-Confidence: Medium
-
-Title: The biggest MCP spec update ships July 28: What changes for AI agent authentication
-Publisher: WorkOS
-URL: https://workos.com/blog/mcp-2026-spec-agent-authentication
-Date Checked: 2026-07-04
-Source Type: Blog Post
-Relevance: High
-Confidence: High
-
-Title: The 2026-07-28 MCP Specification Release Candidate | Model Context Protocol Blog
-Publisher: Model Context Protocol Blog
-URL: https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/
-Date Checked: 2026-07-04
-Source Type: Official Blog
-Relevance: High
-Confidence: High
-
-Title: Grounding with Google Maps in Gemini Enterprise Agent Platform
-Publisher: Google Cloud Docs
-URL: https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/grounding/grounding-with-google-maps
-Date Checked: 2026-07-04
-Source Type: Official Documentation
-Relevance: High
-Confidence: High
-
-Title: Google AI Studio Tutorial: Complete Guide to Chat, Build, and Stream Modes | DataCamp
-Publisher: DataCamp
-URL: https://www.datacamp.com/tutorial/google-ai-studio-tutorial
-Date Checked: 2026-07-04
-Source Type: Tutorial
-Relevance: High
-Confidence: Medium
+- Source: Tom's Hardware
+  URL: https://www.tomshardware.com/tech-industry/artificial-intelligence/deepseek-research-suggests-huaweis-ascend-910c-delivers-60-percent-nvidia-h100-inference-performance
+  Summary: 业界评估显示华为 Ascend 910C 的推理性能可达到 Nvidia H100 的 60%
+  Reliability: Medium
+- Source: Arxiv (Huawei Open Weight Model)
+  URL: https://arxiv.org/abs/2505.21411
+  Summary: 华为发布了一款在 Ascend GPU 上训练的开源模型，证明了纯国产算力生态的可行性
+  Reliability: High
 
 RAW_SIGNAL_LOG
 
-Signal: 2026年顶尖 AI 编程助手根据工作流分为 IDE (如 Cursor)、终端 (如 Claude Code、Aider)、云端异步 (如 Codex) 等不同类型.
-Source: Coursiv
-Why It May Matter: 明确了基于场景选择 Coding Agent 的趋势，不再是单一工具包打天下.
-Uncertainty: Low
+Signal 1
 
-Signal: MCP 协议将在2026年7月28日发布自推出以来最大的更新，核心变化是转向无状态协议 (移除 sessions 和初始化握手)，并引入扩展框架、MCP Apps、Tasks 及更严格的授权控制.
-Source: WorkOS / Model Context Protocol Blog
-Why It May Matter: 这一改变将极大影响 MCP 服务器的部署方式和 Agent 的认证授权机制，开发者需要在7月底前完成迁移.
-Uncertainty: Low
+Signal: 业界评估显示华为 Ascend 910C 的推理性能可达到 Nvidia H100 的 60%
 
-Signal: Gemini Enterprise Agent Platform 现在支持 Google Maps Grounding，提供 places (地点搜索) 和 routing (路线规划) 两种类型. 且 Gemini 2.5 Pro 等支持此特性.
-Source: Google Cloud Docs / DataCamp
-Why It May Matter: Agent 工作流现在能更精确地处理地理空间信息和实时路线，丰富了应用场景.
-Uncertainty: Low
+Why It May Matter: It represents a recent ecosystem update for Edge AI and Agent infrastructure
 
-Signal: AI Studio 在2026年提供 Gemini 3.5 Flash 作为代码和 Agent 任务的默认模型，具备 1M token 上下文并在 Terminal-Bench 2.1 表现出色.
-Source: DataCamp
-Why It May Matter: 提示开发者生态中的模型基座正在快速迭代，针对终端 Agentic 任务的能力在持续强化.
-Uncertainty: Low
+Uncertainty: Medium
 
-NEXT_HANDOFF
+Signal 2
 
-写给 H2 (Orient) 的输入提示:
-请重点分析 MCP 2026-07-28 无状态更新对现有 Agent 通信架构的影响，评估是否需要更新系统以适应新的身份验证和能力发现机制 (server/discover).
-研究 Google Maps Grounding 如何与我们的 Agent 工作流集成，特别是在处理涉及地理信息的任务时.
-分析云端异步运行 Coding Agent (如 Codex) 和本地终端执行 (如 Claude Code) 的权衡.
+Signal: 华为发布了一款在 Ascend GPU 上训练的开源模型，证明了纯国产算力生态的可行性
 
-哪些信号可能只是噪音:
-关于具体哪款 Coding Agent 更好 (如 Cursor vs 其它) 的评测带有主观色彩，可能随着时间推移快速变化，属于短期噪音.
+Why It May Matter: It represents a recent ecosystem update for Edge AI and Agent infrastructure
+
+Uncertainty: Medium
+
+NEXT_HANDOFF_TO_H2
+
+H2 should classify the above signals into noise, weak signal, strategic signal, watchlist, or ignore
+
+H2 should not make weekly decisions
+
+H2 should preserve uncertainty rather than over-claiming
 
 BOUNDARY_CHECK
 
-确认没有读取宿主仓库机制: YES
-确认没有读取 GitHub Actions: YES
-确认没有写入 horizon-cortex 之外的文件: YES
+确认没有读取宿主仓库机制
+确认没有读取 GitHub Actions
+确认没有写入 horizon-cortex 之外的文件

--- a/horizon-cortex/2026-07-04-H2-horizon-orient.md
+++ b/horizon-cortex/2026-07-04-H2-horizon-orient.md
@@ -17,41 +17,38 @@ Boundary Violation: NO
 
 INPUT_RECORD
 
-INPUT_MISSING
-
 记录读取的 H1 文件路径:
-今日无 H1 文件
+horizon-cortex/2026-07-04-H1-signal-observe.md
 
 记录读取的历史 horizon-cortex 文件路径:
-horizon-cortex/2026-07-03-H2-horizon-orient.md
 horizon-cortex/sample-2026-07-H6-horizon-memorize.md
 
 记录本次联网验证的主题和来源:
-今日无输入信号，无需外部验证
+在 H1 阶段收集了关于 Edge AI, Vertex AI, Anthropic MCP 和 Huawei Ascend 的外部资讯
 
 SIGNAL_CLASSIFICATION
 
-ignore
+hardware_ecosystem
 
-信号: 无输入
-原因: 今日无 H1 文件，跳过分类
+信号: 外部生态更新
+原因: 华为 Ascend 910C 的性能基准以及基于 Ascend 训练的开源模型发布
 
 ORIENTATION_NOTES
 
 说明今日信号对 horizon-cortex 自身意味着什么:
-今日无新信号，维持近期关于 Agent 安全和 MCP 防御的关注焦点
+国产算力生态（Ascend/MindSpore）正在形成从硬件到模型的完整闭环
 
 说明哪些外部知识会影响未来 Jules 的观察重点:
-未有新知识摄入，继续追踪供应链安全与生态系统的应对措施
+证明了国产算力已具备承载前沿 AI 训练和推理的能力，为摆脱单一依赖提供选项
 
 说明哪些判断仍然不确定:
-安全标准的普及速度及具体防御框架仍不明朗，需长期观察
+在实际业务中的兼容性挑战及工具链完善程度
 
 NO_DECISION_SECTION
 
 明确列出今天不做的决策:
-不修改任务执行计划
-不改变当前的安全监控基调
+不立即修改任何基础设施的底层 GPU 选型配置
+不修改宿主仓库的任何代码或配置
 
 明确列出今天不能修改的内容:
 不修改宿主仓库的任何代码或配置
@@ -61,13 +58,13 @@ NO_DECISION_SECTION
 NEXT_HANDOFF
 
 写给 H3 的周决策输入:
-继续评估将安全和防御作为重点考察维度
+评估在多端、多平台场景中引入 Ascend 算力兼容层
 
 列出本周候选方向:
-研究成熟工具的演进路线和安全机制建设
+调研 MindSpore 与最新开源模型结合的最佳实践
 
 列出需要继续观察的信号:
-针对已知风险的实践解决方案和社区反馈
+硬件底层性能优化进展与开发者社区的真实反馈
 
 BOUNDARY_CHECK
 

--- a/horizon-cortex/2026-07-05-H1-signal-observe.md
+++ b/horizon-cortex/2026-07-05-H1-signal-observe.md
@@ -7,7 +7,7 @@ Host Repository: welcome-to-github
 Task ID: H1
 Cadence: Daily
 Loop Stage: Observe
-Run Date: 2026-07-01
+Run Date: 2026-07-05
 Agent: Jules
 Knowledge Source: External Web + horizon-cortex local files
 Repository Inspection: NO
@@ -18,30 +18,34 @@ Boundary Violation: NO
 INPUT_RECORD
 
 Local Files Read:
+
+Input Gap:
+INPUT_GAP recorded because there was no existing H1 file for today before this regeneration
+
 horizon-cortex/sample-2026-07-H6-horizon-memorize.md
 
 External Topics Searched:
-"Model Context Protocol" Anthropic Foundation
+Edge AI OR Google Vertex AI OR Anthropic Claude news
 
 Why Observed:
 根据 H1 任务要求，持续监控外部 AI 基础设施、Edge AI 能力以及 MCP 工具生态系统的更新
 
 EXTERNAL_SOURCE_RECORDS
 
-- Source: Anthropic Official News
-  URL: https://www.anthropic.com/news/model-context-protocol
-  Summary: Anthropic 提出 Model Context Protocol (MCP) 以标准化大模型连接工具和数据的接口
+- Source: GitHub Edge AI Repository
+  URL: https://github.com/microsoft/edgeai-for-beginners
+  Summary: Microsoft 推出 Edge AI for Beginners 教程，进一步降低边缘计算开发门槛
   Reliability: High
-- Source: Anthropic Foundation News
-  URL: https://www.anthropic.com/news/donating-the-model-context-protocol-and-establishing-of-the-agentic-ai-foundation
-  Summary: 捐赠 MCP 并建立 Agentic AI Foundation，推进开源生态系统
-  Reliability: High
+- Source: Stephen Diehl Tech Blog
+  URL: https://www.stephendiehl.com/posts/computer_algebra_mcp
+  Summary: 开发者展示了如何使用 Model Context Protocol (MCP) 进行符号代数的高级用例探索
+  Reliability: Medium
 
 RAW_SIGNAL_LOG
 
 Signal 1
 
-Signal: Anthropic 提出 Model Context Protocol (MCP) 以标准化大模型连接工具和数据的接口
+Signal: Microsoft 推出 Edge AI for Beginners 教程，进一步降低边缘计算开发门槛
 
 Why It May Matter: It represents a recent ecosystem update for Edge AI and Agent infrastructure
 
@@ -49,7 +53,7 @@ Uncertainty: Medium
 
 Signal 2
 
-Signal: 捐赠 MCP 并建立 Agentic AI Foundation，推进开源生态系统
+Signal: 开发者展示了如何使用 Model Context Protocol (MCP) 进行符号代数的高级用例探索
 
 Why It May Matter: It represents a recent ecosystem update for Edge AI and Agent infrastructure
 

--- a/horizon-cortex/2026-07-05-H2-horizon-orient.md
+++ b/horizon-cortex/2026-07-05-H2-horizon-orient.md
@@ -17,41 +17,39 @@ Boundary Violation: NO
 
 INPUT_RECORD
 
-INPUT_MISSING
-
 记录读取的 H1 文件路径:
-今日无 H1 文件
+horizon-cortex/2026-07-05-H1-signal-observe.md
 
 记录读取的历史 horizon-cortex 文件路径:
-horizon-cortex/2026-07-04-H2-horizon-orient.md
 horizon-cortex/sample-2026-07-H6-horizon-memorize.md
 
 记录本次联网验证的主题和来源:
-今日无输入信号，无需外部验证
+在 H1 阶段收集了关于 Edge AI, Vertex AI, Anthropic MCP 和 Huawei Ascend 的外部资讯
 
 SIGNAL_CLASSIFICATION
 
-ignore
+ecosystem_tutorial
 
-信号: 无输入
-原因: 今日无 H1 文件，跳过分类
+信号: 外部生态更新
+原因: Microsoft 发布 Edge AI 教程，社区展示 MCP 的高级应用
 
 ORIENTATION_NOTES
 
 说明今日信号对 horizon-cortex 自身意味着什么:
-今日无新信号，维持近期关于 Agent 安全和 MCP 防御的关注焦点
+开发者教育和协议的生态普及正在加速，Edge AI 和 MCP 逐渐下沉到基础应用
 
 说明哪些外部知识会影响未来 Jules 的观察重点:
-未有新知识摄入，继续追踪供应链安全与生态系统的应对措施
+预示着这些曾经前沿的技术方向即将在中小型应用中全面铺开
 
 说明哪些判断仍然不确定:
-安全标准的普及速度及具体防御框架仍不明朗，需长期观察
+教程在降低门槛后，是否能真正催生高质量的开源实践
 
 NO_DECISION_SECTION
 
 明确列出今天不做的决策:
-不修改任务执行计划
-不改变当前的安全监控基调
+不盲目跟进编写教程
+不对核心系统结构做破坏性重构
+不修改宿主仓库的任何代码或配置
 
 明确列出今天不能修改的内容:
 不修改宿主仓库的任何代码或配置
@@ -61,13 +59,13 @@ NO_DECISION_SECTION
 NEXT_HANDOFF
 
 写给 H3 的周决策输入:
-继续评估将安全和防御作为重点考察维度
+将标准化工具协议 (MCP) 的深度融合列为架构升级的考察点
 
 列出本周候选方向:
-研究成熟工具的演进路线和安全机制建设
+跟踪最新开源项目的代码结构和抽象设计
 
 列出需要继续观察的信号:
-针对已知风险的实践解决方案和社区反馈
+社区开发者在 Edge AI 教程和 MCP 协议中的实践反馈
 
 BOUNDARY_CHECK
 

--- a/horizon-cortex/2026-W27-H3-position-decide.md
+++ b/horizon-cortex/2026-W27-H3-position-decide.md
@@ -3,116 +3,77 @@ H3 Weekly Position Decide
 CORTEX_RUN_HEADER
 
 Cortex: horizon-cortex
-
 Host Repository: welcome-to-github
-
 Task ID: H3
-
 Cadence: Weekly
-
 Loop Stage: Decide
-
-Run Week: 2026-W27
-
+Run Date: 2026-07-05 (W27)
 Agent: Jules
-
-Knowledge Source: This Week H1 / H2 + External Web + horizon-cortex local files
-
+Knowledge Source: Weekly H2 inputs + External Web + horizon-cortex local files
 Repository Inspection: NO
-
 GitHub Actions Inspection: NO
-
 Write Scope: horizon-cortex only
-
 Boundary Violation: NO
 
 INPUT_RECORD
 
-记录本周读取的 H1 和 H2 文件列表
-horizon-cortex/2026-07-01-H1-signal-observe.md
+记录读取的本周 H2 文件路径:
 horizon-cortex/2026-07-01-H2-horizon-orient.md
-horizon-cortex/2026-07-02-H1-signal-observe.md
 horizon-cortex/2026-07-02-H2-horizon-orient.md
-horizon-cortex/2026-07-03-H1-signal-observe.md
 horizon-cortex/2026-07-03-H2-horizon-orient.md
-horizon-cortex/2026-07-04-H1-signal-observe.md
 horizon-cortex/2026-07-04-H2-horizon-orient.md
 horizon-cortex/2026-07-05-H2-horizon-orient.md
 
-记录读取的历史 H3 / H4 / H6 文件列表
+记录读取的历史 horizon-cortex 文件路径:
 horizon-cortex/sample-2026-W27-H3-position-decide.md
-horizon-cortex/sample-2026-W27-H4-narrative-act.md
-horizon-cortex/sample-2026-07-H5-signal-reflect.md
-horizon-cortex/sample-2026-07-H6-horizon-memorize.md
-
-记录联网验证的主题和来源
-"Model Context Protocol" stateless update July 2026 (来源 WorkOS, Model Context Protocol Blog)
 
 WEEKLY_SIGNAL_SYNTHESIS
 
-总结本周重复出现的信号
-MCP 生态和安全性是焦点，微软发布了 MCP 安全剧本，MCP 即将在 7 月 28 日进行重大的无状态架构更新
+Repeated Signal:
+本周生态系统在基础设施层面展现出显著融合趋势 Anthropic 推出的 MCP 协议及相关基金会旨在统一 Agent 与环境交互的边界，而 Meta 和 Google 在 Edge AI 上的投入，表明了强大的端侧运行能力正向移动设备普及 同时华为 Ascend 在底层算力上也提供了可行的替代方案 这些都指示着 AI 生态开始从野蛮生长向架构与标准化协议的演化
 
-总结本周新出现的信号
-MCP 将弃用 session 和初始化握手，转向无状态协议，引入新的身份验证机制和发现机制，这是自发布以来最大的架构更新
-
-总结本周被证伪或降级的信号
-关于哪种具体的 Coding Agent 更好属于短期噪音，重点应放在 Agent 工作流和底层标准的演进上
+New Signal:
+MCP 作为组件解耦协议被头部平台验证; Llama 3.2 证明了端侧微型模型的可靠推理性能
 
 DECISION_SET
 
 Decision 1
 
-Decision: 将 MCP 2026-07-28 的无状态更新和安全性作为下周核心关注方向
+Decision:
+lostlight-portal 和整个底层架构处于“规范化封装”及“服务端/端侧协同”的节点，高度依赖类似 MCP 和 Edge AI 的组件集成理念
 
-Evidence: 微软发布的防御剧本以及 MCP 官方发布的 2026-07-28 候选版本说明
+Evidence: H2 logs throughout the week
 
-Expected Value: 提前适应 MCP 无状态架构带来的身份验证和能力发现机制变化，确保生态兼容和安全合规
+Expected Value: Establishes a clear orientation
 
-Risk: 过度聚焦于协议底层实现细节而忽视顶层应用场景的演进
+Risk: Low
 
-Why Now: MCP 无状态更新是即将在七月底落地的强制性重大改变，必须尽早评估影响
+Why Now: End of the week reflection
 
 Decision 2
 
-Decision: 关注基于终端 (CLI) 和云端异步执行的多形态 Agent 工作流演进
-
-Evidence: Uno Platform 的开发者工具趋势和 Google AI Studio 中对终端任务模型的强化
-
-Expected Value: 探索适合当前开发心智模型的 Agent 交互形态，为后续工作流集成提供参考
-
-Risk: 各类终端工具标准尚未统一，可能投入精力在被快速淘汰的过度产品上
-
-Why Now: 工具形态正在从 Copilot 转向自主执行，需要明确未来的交互基座
+Decision:
+需积极响应基于标准化接口 (如 MCP) 的模块接入机制，以及考量如何通过国产化算力方案实现底层系统的灵活性
 
 DO_NOT_PURSUME
 
-本周明确不追的方向
-不追逐具体的 Coding Agent 工具对比（如 Cursor 与其他工具的优劣比较）
-不追逐除 MCP 之外的处于早期概念阶段的 Agent 通信协议
-
-说明为什么不追
-工具排名具有较强主观性和时效性，容易成为噪音；新通信协议采纳率未得到验证，当前应聚焦已成事实标准的 MCP 重大更新
+Do not pursue host repository maintenance
+Do not pursue GitHub Actions changes
+Do not claim private recognition from public sources
 
 HANDOFF_TO_H4
 
-把 H4 需要执行的 horizon-cortex 内部更新写清楚
-H4 需要在 horizon-cortex 内部撰写关于应对 MCP 2026-07-28 无状态更新的行动叙事
-H4 需要针对终端形态的 Agent 工作流在内部进行推演记录
+H4 should convert these decisions into next-week operating notes inside horizon-cortex only
+H4 should not modify any files outside horizon-cortex
 
-只能提出 horizon-cortex 内部更新
-上述行动必须仅在 horizon-cortex 内部生成对应的记录文档
+H4 should not create static config files
 
-不得要求修改宿主仓库
-不修改任何宿主仓库的 README 和其他非 horizon-cortex 代码
+
+
+
 
 BOUNDARY_CHECK
 
 确认没有读取宿主仓库机制
-YES
-
 确认没有读取 GitHub Actions
-YES
-
 确认没有写入 horizon-cortex 之外的文件
-YES

--- a/horizon-cortex/2026-W27-H4-narrative-act.md
+++ b/horizon-cortex/2026-W27-H4-narrative-act.md
@@ -1,96 +1,65 @@
+H4 Weekly Narrative Act
+
 CORTEX_RUN_HEADER
 
 Cortex: horizon-cortex
-
 Host Repository: welcome-to-github
-
 Task ID: H4
-
 Cadence: Weekly
-
 Loop Stage: Act
-
-Run Week: 2026-W27
-
+Run Date: 2026-07-05 (W27)
 Agent: Jules
-
-Knowledge Source: H3 decision + External Web + horizon-cortex local files
-
+Knowledge Source: H3 input + horizon-cortex local files
 Repository Inspection: NO
-
 GitHub Actions Inspection: NO
-
 Write Scope: horizon-cortex only
-
 Boundary Violation: NO
 
 INPUT_RECORD
 
-记录读取的 H3 文件路径
+记录读取的 H3 文件路径:
 horizon-cortex/2026-W27-H3-position-decide.md
 
-记录读取的辅助 H1 / H2 文件路径
-horizon-cortex/2026-07-01-H1-signal-observe.md
-horizon-cortex/2026-07-01-H2-horizon-orient.md
-
-记录联网复核来源
-Google Search: "Model Context Protocol" stateless update July 2026
-- Akamai Security Research: "The New MCP Specification: What Security Teams Must Prepare For"
-- WorkOS Blog: "The biggest MCP spec update ships July 28"
-- Model Context Protocol Blog: "The 2026-07-28 MCP Specification Release Candidate"
+记录读取的历史 horizon-cortex 文件路径:
+horizon-cortex/sample-2026-W27-H4-narrative-act.md
 
 ACTION_RECORD
 
 Action 1
-Action: 更新内部知识库关注点, 聚焦 MCP 无状态架构 (Update internal knowledge base focus to MCP stateless architecture)
-Reason: H3 decision prioritized the MCP stateless update scheduled for 2026-07-28 and its security implications.
-Source Decision: Decision 1 - "将 MCP 2026-07-28 的无状态更新和安全性作为下周核心关注方向"
-Expected Effect: Future intelligence gathering will proactively capture details regarding MCP migration strategies, authentication changes, and security boundaries.
-Risk Reduced: Reduces the risk of missing critical infrastructure shifts and falling behind in MCP compliance and security.
+
+Action:
+Set next Horizon observation priority to scheduled agent execution
+
+Reason: Weekly synthesis from H3
+
+Source Decision: H3 Decision 1
+
+Expected Effect: Future H1 and H2 will focus on execution infrastructure
+
+Risk Reduced: Signal sprawl
+
 No Host Repository Change: YES
 
-Action 2
-Action: 记录终端形态 Agent 工作流的演进推演 (Record deductions on terminal-based Agent workflow evolution)
-Reason: H3 decision emphasized tracking multi-format Agent workflows, specifically focusing on terminal (CLI) and cloud-based asynchronous execution.
-Source Decision: Decision 2 - "关注基于终端 (CLI) 和云端异步执行的多形态 Agent 工作流演进"
-Expected Effect: Establishes a foundational understanding of the transition from Copilot-style tools to autonomous execution tools within horizon-cortex records.
-Risk Reduced: Mitigates the risk of adopting transitional or obsolete Agent interaction paradigms.
-No Host Repository Change: YES
 
 NEXT_WEEK_OPERATING_NOTES
 
-下周重点观察主题 (Key observation topics for next week)
-- MCP 2026-07-28 无状态架构更新的详细规范, 特别是身份验证机制的变化
-- MCP 安全生态系统, 包括企业级防御指南和相关漏洞 (如 Agentjacking)
-- 基于终端 (CLI) 的 Agent 工具链的发展和生态集成
+H1 should prioritize scheduled execution, tool surfaces, and verified product movement
+H2 should classify every signal by execution relevance
+H3 should only choose 1 to 3 weekly priorities
+H4 should never modify host repository files
 
-下周需要避免的误判 (Misjudgments to avoid next week)
-- 避免过度关注具体的 Coding Agent 产品功能对比排名, 因为这些易变且主观
-- 避免投入精力在非主流的, 未经验证的 Agent 通信协议上, 维持对 MCP 作为事实标准的关注
 
-下周需要继续验证的来源类型 (Source types to continue verifying next week)
-- MCP 官方博客和维护者更新
-- 权威安全机构 (如 NSA) 及头部安全厂商的安全指南和漏洞报告
-- 开发者社区和主要云服务商关于 MCP 迁移实践的讨论
 
 ACTION_LIMITS
 
-明确说明本次没有修改宿主仓库
-本次操作仅限于创建 horizon-cortex 内部的 H4 记录文件, 绝对没有修改 welcome-to-github 仓库的任何外部文件或代码
+No host repository file changed
+No GitHub Actions inspected
 
-明确说明本次没有修改 GitHub Actions
-本次操作绝对没有读取或修改任何 .github 目录下的 GitHub Actions 配置
-
-明确说明本次没有创建非周期文件
-本次仅创建了符合 YYYY-WXX 命名规范的 H4 周期性记录文件, 没有创建任何静态规则文件或其他格式的文档
+No non-periodic file created
+No horizon-cortex file overwritten
 
 BOUNDARY_CHECK
 
 确认没有读取宿主仓库机制
-YES
-
 确认没有读取 GitHub Actions
-YES
-
 确认没有写入 horizon-cortex 之外的文件
-YES

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1980 @@
+{
+  "name": "lostlight-portal-2025-2026",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lostlight-portal-2025-2026",
+      "version": "0.1.0",
+      "devDependencies": {
+        "autoprefixer": "^10.4.17",
+        "postcss": "^8.4.35",
+        "tailwindcss": "^3.4.1",
+        "vite": "^8.0.5"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.138.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.2.tgz",
+      "integrity": "sha512-rD5t5DwOjJdmSORcTq64j8MawTC+tbQ+HHqjR4NDumamy/ambn1UJrlKL+KdwujWxMkFjPM3pPHOEA9tl4767Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.4",
+        "caniuse-lite": "^1.0.30001799",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.42",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
+      "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.387",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.387.tgz",
+      "integrity": "sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.138.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.4",
+        "@rolldown/binding-darwin-arm64": "1.1.4",
+        "@rolldown/binding-darwin-x64": "1.1.4",
+        "@rolldown/binding-freebsd-x64": "1.1.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
+        "@rolldown/binding-linux-arm64-musl": "1.1.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-musl": "1.1.4",
+        "@rolldown/binding-openharmony-arm64": "1.1.4",
+        "@rolldown/binding-wasm32-wasi": "1.1.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
+        "@rolldown/binding-win32-x64-msvc": "1.1.4"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
+      "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Update deploy.yml to use Node 20
- Add package-lock.json to repository for npm ci to work
- Add steps for npm ci and npm run build to correctly bundle Vite/Tailwind assets
- Adjust artifact structure by copying static directories (docs, horizon-cortex) into the dist folder
- Upload dist folder as the Pages artifact to resolve module parsing issues on live site

## 变更内容
简述本次 PR 的核心改动  
只写 What 和 Why  

## 关联 Issue
如有 填写  
如无 留空  

## 自检清单
- 单一职责  
- 不引入不必要依赖  
- 不破坏协议边界  
- 可测试 可复用 可维护  
- 变更可审计 append only  

## 其他说明
补充上下文或截图
