### PR TITLE
Create H2 Daily Horizon Orient for 2026-07-07

### DIFF
--- a/horizon-cortex/2026-07-07-H2-horizon-orient.md
+++ b/horizon-cortex/2026-07-07-H2-horizon-orient.md
@@ -1,0 +1,70 @@
+CORTEX_RUN_HEADER
+
+Cortex: horizon-cortex
+Host Repository: welcome-to-github
+Task ID: H2
+Cadence: Daily
+Loop Stage: Orient
+Run Date: 2026-07-07
+Agent: Jules
+Knowledge Source: H1 input + External Web + horizon-cortex local files
+Repository Inspection: NO
+GitHub Actions Inspection: NO
+Write Scope: horizon-cortex only
+Boundary Violation: NO
+
+INPUT_RECORD
+
+记录读取的 H1 文件路径:
+INPUT_MISSING
+
+记录读取的历史 horizon-cortex 文件路径:
+horizon-cortex/2026-07-06-H2-horizon-orient.md
+horizon-cortex/sample-2026-07-H6-horizon-memorize.md
+
+记录本次联网验证的主题和来源:
+"Model Context Protocol", "Edge AI", "Maps Grounding Lite MCP"
+
+SIGNAL_CLASSIFICATION
+
+None
+由于 H1 文件缺失，今天没有具体的 H1 信号可以分类.
+
+ORIENTATION_NOTES
+
+说明今日信号对 horizon-cortex 自身意味着什么:
+由于缺乏 H1 输入，今天无法进行直接的信号分析，但通过外部搜索确认了 MCP (Model Context Protocol) 正在向企业级功能 (如集中式认证) 和具体领域 (如边缘推理) 演进. 边缘 AI 领域的竞争开始从数据中心向边缘推理转移，例如部署在工厂和零售商店的模型.
+
+说明哪些外部知识会影响未来 Jules 的观察重点:
+MCP 的 2026 路线图显示了从本地工具连接向企业级应用，传输可扩展性以及 Agent 通信发展的趋势. 边缘 AI 推理的发展也可能促进 MCP 在更广泛的设备上的集成.
+
+说明哪些判断仍然不确定:
+在边缘 AI 推理生态中，MCP 如何在资源受限的环境中保持性能依然需要观察.
+
+NO_DECISION_SECTION
+
+明确列出今天不做的决策:
+不修改任何架构.
+不调整监控重心.
+
+明确列出今天不能修改的内容:
+不修改宿主仓库的任何代码或配置.
+不读取 GitHub Actions.
+不写入 horizon-cortex 以外的任何文件.
+
+NEXT_HANDOFF
+
+写给 H3 的周决策输入:
+建议将 MCP 的企业级应用场景以及边缘推理领域的 AI 生态作为观察重点.
+
+列出本周候选方向:
+垂直领域 MCP 服务器生态研究以及企业级 MCP 认证演进.
+
+列出需要继续观察的信号:
+MCP 2026 路线图各项增强特性的发布进展以及边缘计算框架对 MCP 的支持.
+
+BOUNDARY_CHECK
+
+确认没有读取宿主仓库机制.
+确认没有读取 GitHub Actions.
+确认没有写入 horizon-cortex 之外的文件.


### PR DESCRIPTION
Created the H2 orient file for 2026-07-07 in the `horizon-cortex` directory. Since there was no H1 input file, I documented `INPUT_MISSING` and verified the external themes (MCP, Edge AI) via web search based on previous day's context to generate the orientation notes. The generated file strictly avoids Chinese periods and conforms to the specified run header structure and boundary constraints.

---
*PR created automatically by Jules for task [9725659063506935344](https://jules.google.com/task/9725659063506935344) started by @lostlight530*