### PR TITLE
Add daily H1 signal observe report for 2026-07-07

### DIFF
--- a/horizon-cortex/2026-07-07-H1-signal-observe.md
+++ b/horizon-cortex/2026-07-07-H1-signal-observe.md
@@ -1,0 +1,101 @@
+H1 Daily Signal Observe
+
+CORTEX_RUN_HEADER
+Cortex: horizon-cortex
+Host Repository: welcome-to-github
+Task ID: H1
+Cadence: Daily
+Loop Stage: Observe
+Run Date: 2026-07-07
+Agent: Jules
+Knowledge Source: External Web + horizon-cortex local files
+Repository Inspection: NO
+GitHub Actions Inspection: NO
+Write Scope: horizon-cortex only
+Boundary Violation: NO
+
+INPUT_RECORD
+Local Files Read:
+horizon-cortex/2026-07-06-H1-signal-observe.md
+
+External Topics Searched:
+AI Agent, MCP, Coding Agent, Developer tooling, Google Maps Grounding, Gemini, AI Studio, Agent workflow, Async execution, Open source governance
+
+Why Observed:
+根据 H1 任务要求，必须监控外部 AI 基础设施、Edge AI 能力以及 MCP 工具生态系统的更新，从而为自身系统的进化提供外部知识输入 (Monitor external AI infrastructure, Edge AI capabilities, and MCP tool ecosystem updates as per H1 requirements to provide external knowledge for system evolution)
+
+EXTERNAL_SOURCE_RECORDS
+
+Source 1
+Title: How AI agents use tools and MCP
+Publisher: Neo4j
+URL: https://neo4j.com/blog/agentic-ai/agent-tools/
+Date Checked: 2026-07-07
+Source Type: Tech Blog
+Relevance: Explains agent tool categories and how MCP standardizes integration
+Confidence: High
+
+Source 2
+Title: Grounding with Google Maps in Gemini Enterprise Agent Platform
+Publisher: Google Cloud
+URL: https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/grounding/grounding-with-google-maps
+Date Checked: 2026-07-07
+Source Type: Official Documentation
+Relevance: Details how to enable Google Maps grounding (places, routing) in Vertex AI Studio for Gemini
+Confidence: High
+
+Source 3
+Title: MCP Servers Explained: What They Are and Why Every AI Agent Needs Them
+Publisher: MindStudio
+URL: https://www.mindstudio.ai/blog/mcp-servers-explained-ai-agents
+Date Checked: 2026-07-07
+Source Type: Tech Blog
+Relevance: Highlights the necessity of MCP servers for AI agents to interact with external systems structuredly
+Confidence: High
+
+Source 4
+Title: Introducing Quarkus Agent MCP: teaching AI agents to speak Quarkus
+Publisher: Quarkus
+URL: https://quarkus.io/blog/introducing-agent-mcp/
+Date Checked: 2026-07-07
+Source Type: Tech Blog
+Relevance: Shows integration of coding agents with Quarkus via MCP
+Confidence: Medium
+
+RAW_SIGNAL_LOG
+
+Signal 1
+Signal: MCP 继续确立其作为 AI 应用标准化工具集成协议的地位，不仅仅是代理，更是核心转换层 (MCP continues to establish itself as the standard tool integration protocol for AI apps, acting as a core transformation layer rather than just a proxy)
+Source: MindStudio, Neo4j
+Why It May Matter: 优秀的 MCP 服务器不仅仅是 API 代理，还能对数据进行转换以适应 Agent 的读取，这能解决复杂嵌套 JSON 带来的困惑 (Good MCP servers transform data for agent readability, solving confusion from complex nested JSON)
+Uncertainty: Low
+
+Signal 2
+Signal: Google Gemini 平台引入了原生的 Google Maps Grounding 支持 (Google Gemini platform introduces native Google Maps Grounding support)
+Source: Google Cloud
+Why It May Matter: 开发者现在可以直接在 Vertex AI Studio 中启用基于地理位置的 Grounding (places, routing)，这将极大提升空间相关推理任务的准确度 (Developers can now enable geolocation-based grounding directly in Vertex AI Studio, greatly improving accuracy for spatial reasoning tasks)
+Uncertainty: Low
+
+Signal 3
+Signal: 编程辅助工具 (Coding Agents) 正在加速拥抱 MCP 生态 (Coding Agents are accelerating their adoption of the MCP ecosystem)
+Source: Quarkus
+Why It May Matter: 主流编码代理 (Claude Code, Cursor, GitHub Copilot 等) 现在可以通过标准的 MCP 协议无缝接入特定框架的开发工具链中 (Mainstream coding agents can now seamlessly integrate with framework-specific developer toolchains via the standard MCP protocol)
+Uncertainty: Low
+
+NEXT_HANDOFF
+
+写给 H2 的输入提示:
+请全面评估上述关于 MCP 架构中数据转换层的重要性以及 Gemini 引入 Google Maps Grounding 的新能力 (Please comprehensively evaluate the importance of the data transformation layer in MCP architecture and the new capabilities of Gemini introducing Google Maps Grounding)
+
+指出哪些信号需要明天或今天的 Orient 任务解释:
+MCP 服务器在数据转换层 (Data Transformation Layer) 的具体最佳实践对现有系统架构的影响需要进一步分析 (The specific best practices of MCP servers in the data transformation layer and their impact on existing system architecture require further analysis)
+Gemini 的地理 Grounding 功能如何与我们当前的 Edge AI 或数据获取管道结合 (How Gemini's geographic grounding features can be integrated with our current Edge AI or data acquisition pipelines)
+
+指出哪些信号可能只是噪音:
+部分针对特定语言框架 (如 Quarkus) 的 MCP 客户端实现可能由于针对性过强而属于系统级噪音 (Some MCP client implementations for specific language frameworks like Quarkus may be too specific and act as system-level noise)
+
+BOUNDARY_CHECK
+
+确认没有读取宿主仓库机制: YES
+确认没有读取 GitHub Actions: YES
+确认没有写入 horizon-cortex 之外的文件: YES


### PR DESCRIPTION
This commit introduces the daily H1 signal observe report (`horizon-cortex/2026-07-07-H1-signal-observe.md`).

Key additions:
- Observed external signals regarding Model Context Protocol (MCP) data transformation layers.
- Documented new capabilities of Gemini with Google Maps Grounding.
- Logged updates on Coding Agents integrating with the MCP ecosystem.

Boundary constraints were strictly followed (no reading of host repo/mechanisms, no writes outside `horizon-cortex`). Formatting compliance, such as using `NO_CHINESE_PERIODS`, was explicitly verified.

---
*PR created automatically by Jules for task [5135317617061353357](https://jules.google.com/task/5135317617061353357) started by @lostlight530*