### PR TITLE
docs(horizon-cortex): run H2 Daily Horizon Orient for 2026-07-08

### DIFF
--- a/horizon-cortex/2026-07-08-H2-horizon-orient.md
+++ b/horizon-cortex/2026-07-08-H2-horizon-orient.md
@@ -1,0 +1,87 @@
+CORTEX_RUN_HEADER
+
+Cortex: horizon-cortex
+Host Repository: welcome-to-github
+Task ID: H2
+Cadence: Daily
+Loop Stage: Orient
+Run Date: 2026-07-08
+Agent: Jules
+Knowledge Source: H1 input + External Web + horizon-cortex local files
+Repository Inspection: NO
+GitHub Actions Inspection: NO
+Write Scope: horizon-cortex only
+Boundary Violation: NO
+
+INPUT_RECORD
+
+记录读取的 H1 文件路径:
+INPUT_MISSING
+
+记录读取的历史 horizon-cortex 文件路径:
+horizon-cortex/2026-07-07-H2-horizon-orient.md
+horizon-cortex/sample-2026-07-H6-horizon-memorize.md
+
+记录本次联网验证的主题和来源:
+"Anthropic MCP Model Context Protocol roadmap or edge AI inference updates 2026-07"
+
+SIGNAL_CLASSIFICATION
+
+noise:
+None
+Due to the missing H1 file, there are no specific H1 signals to classify today. / 由于 H1 文件缺失，今天没有具体的 H1 信号可以分类.
+
+weak signal:
+None
+Due to the missing H1 file, there are no specific H1 signals to classify today. / 由于 H1 文件缺失，今天没有具体的 H1 信号可以分类.
+
+strategic signal:
+None
+Due to the missing H1 file, there are no specific H1 signals to classify today. / 由于 H1 文件缺失，今天没有具体的 H1 信号可以分类.
+
+watchlist:
+None
+Due to the missing H1 file, there are no specific H1 signals to classify today. / 由于 H1 文件缺失，今天没有具体的 H1 信号可以分类.
+
+ignore:
+None
+Due to the missing H1 file, there are no specific H1 signals to classify today. / 由于 H1 文件缺失，今天没有具体的 H1 信号可以分类.
+
+ORIENTATION_NOTES
+
+说明今日信号对 horizon-cortex 自身意味着什么:
+Due to lack of H1 input, no direct signal analysis from H1 can be performed today. However, external searches confirm that the 2026-07-28 MCP Specification Release Candidate delivers on the 2026 roadmap, introducing a stateless core that scales on ordinary HTTP infrastructure, server-rendered UIs through MCP Apps, and long-running work through the Tasks extension. / 由于缺乏 H1 输入，今天无法进行直接的信号分析，但通过外部搜索确认了 2026-07-28 MCP 规范发布候选版兑现了 2026 路线图，引入了在普通 HTTP 基础设施上扩展的无状态核心，通过 MCP Apps 提供的服务器渲染 UI，以及通过 Tasks 扩展支持的长时间运行任务.
+
+说明哪些外部知识会影响未来 Jules 的观察重点:
+The major revisions to the MCP protocol, particularly the Tasks extension for long-running work and stateless core, will significantly impact how scheduled agent executions and MCP tool orchestration are tracked. / MCP 协议的重大修订，特别是用于长时间运行任务的 Tasks 扩展和无状态核心，将显着影响如何跟踪计划内的 Agent 执行和 MCP 工具编排.
+
+说明哪些判断仍然不确定:
+The adoption rate of the new MCP Tasks extension and how it integrates with existing execution surfaces remains uncertain and needs to be monitored. / 新的 MCP Tasks 扩展的采用率以及它如何与现有的执行面集成仍然不确定，需要继续监控.
+
+NO_DECISION_SECTION
+
+明确列出今天不做的决策:
+Do not modify any architecture. / 不修改任何架构.
+Do not adjust monitoring focus. / 不调整监控重心.
+
+明确列出今天不能修改的内容:
+Do not modify any code or configuration in the host repository. / 不修改宿主仓库的任何代码或配置.
+Do not read GitHub Actions. / 不读取 GitHub Actions.
+Do not write any files outside of horizon-cortex. / 不写入 horizon-cortex 以外的任何文件.
+
+NEXT_HANDOFF
+
+写给 H3 的周决策输入:
+Suggest incorporating the new MCP Tasks extension and its implications for long-running agent workflows into the strategic watchlines. / 建议将新的 MCP Tasks 扩展及其对长时间运行 Agent 工作流的影响纳入战略观察线.
+
+列出本周候选方向:
+Research the impact of the MCP stateless core and Tasks extension on scheduled agent execution. / 研究 MCP 无状态核心和 Tasks 扩展对计划内 Agent 执行的影响.
+
+列出需要继续观察的信号:
+The rollout of the MCP 2026-07-28 Release Candidate and early adoption patterns of MCP Apps and Tasks. / MCP 2026-07-28 发布候选版的推出以及 MCP Apps 和 Tasks 的早期采用模式.
+
+BOUNDARY_CHECK
+
+确认没有读取宿主仓库机制: YES
+确认没有读取 GitHub Actions: YES
+确认没有写入 horizon-cortex 之外的文件: YES


### PR DESCRIPTION
Generates the H2 Daily Horizon Orient task document for 2026-07-08 in `horizon-cortex`. Correctly notes the missing `H1` input and incorporates external research on Anthropic MCP's 2026-07-28 Release Candidate (Tasks extension, stateless core) while strictly obeying constraints (boundary limits, `NO_CHINESE_PERIODS`).

---
*PR created automatically by Jules for task [15036288515635023129](https://jules.google.com/task/15036288515635023129) started by @lostlight530*