### PR TITLE
docs(horizon-cortex): add H1 daily signal observation for 2026-07-08

### DIFF
--- a/horizon-cortex/2026-07-08-H1-signal-observe.md
+++ b/horizon-cortex/2026-07-08-H1-signal-observe.md
@@ -17,30 +17,82 @@ Boundary Violation: NO
 INPUT_RECORD
 Local Files Read:
 horizon-cortex/2026-07-07-H1-signal-observe.md
-horizon-cortex/2026-07-07-H2-horizon-orient.md
 
 External Topics Searched:
-INPUT_MISSING
+AI Agent, MCP, Model Context Protocol, Google Maps Grounding, Gemini, AI Studio, Agent workflow, Async execution, Agent reliability
 
 Why Observed:
-According to H1 task requirements, it is necessary to monitor updates in external AI infrastructure, Edge AI capabilities, and the MCP tool ecosystem to provide external knowledge input for the system's own evolution. (根据 H1 任务要求，必须监控外部 AI 基础设施、Edge AI 能力以及 MCP 工具生态系统的更新，从而为自身系统的进化提供外部知识输入)
+According to H1 task requirements, it is necessary to monitor updates in external AI infrastructure, Agent capabilities, and the MCP tool ecosystem to provide external knowledge input for the system's own evolution. (根据 H1 任务要求，必须监控外部 AI 基础设施、Agent 能力以及 MCP 工具生态系统的更新，从而为自身系统的进化提供外部知识输入)
 
 EXTERNAL_SOURCE_RECORDS
-INPUT_MISSING
+
+Source 1
+Title: The biggest MCP spec update ships July 28: What changes for AI agent authentication
+Publisher: WorkOS
+URL: https://workos.com/blog/mcp-2026-spec-agent-authentication
+Date Checked: 2026-07-08
+Source Type: Tech Blog
+Relevance: Describes the upcoming MCP 2026-07-28 release candidate and major changes to authentication and sessions
+Confidence: High
+
+Source 2
+Title: Grounding with Google Maps in Gemini Enterprise Agent Platform
+Publisher: Google Cloud
+URL: https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/grounding/grounding-with-google-maps
+Date Checked: 2026-07-08
+Source Type: Official Documentation
+Relevance: Explains how to integrate Google Maps Grounding via Vertex AI Studio
+Confidence: High
+
+Source 3
+Title: Bringing the real world to your AI application using Firebase AI Logic
+Publisher: Firebase Blog
+URL: https://firebase.blog/posts/2026/05/ai-logic-maps-grounding/
+Date Checked: 2026-07-08
+Source Type: Official Blog
+Relevance: Details Grounding with Google Maps via Firebase AI Logic to prevent geospatial hallucinations
+Confidence: High
+
+Source 4
+Title: How Async AI Agent Workflows Survive Failures
+Publisher: Augment Code
+URL: https://www.augmentcode.com/guides/async-ai-agent-workflows
+Date Checked: 2026-07-08
+Source Type: Tech Blog
+Relevance: Discusses durable long-running execution for agents to solve timeout and reliability issues
+Confidence: Medium
 
 RAW_SIGNAL_LOG
-INPUT_MISSING
+
+Signal 1
+Signal: The MCP 2026-07-28 release candidate rewrites the protocol's foundation, changing authentication and removing sessions. (MCP 2026-07-28 候选版本重写了协议基础，改变了身份验证并移除了会话)
+Source: WorkOS
+Why It May Matter: It will require updates to existing MCP server integrations before the final spec ships on July 28. (在 7 月 28 日最终规范发布前，这将需要对现有的 MCP 服务器集成进行更新)
+Uncertainty: Low
+
+Signal 2
+Signal: Google Gemini platform introduces native Google Maps Grounding support for places and routing. (Google Gemini 平台引入了原生的 Google Maps Grounding 支持，包含地点和路线)
+Source: Google Cloud, Firebase Blog
+Why It May Matter: Developers can use geographic bias and grounding to prevent geospatial hallucinations in applications. (开发者可以利用地理偏差和 Grounding 来防止应用中的地理空间幻觉)
+Uncertainty: Low
+
+Signal 3
+Signal: Async AI agent workflows require durable long-running execution and state checkpointing to survive timeouts and crashes. (异步 AI 代理工作流需要持久的长时间运行执行和状态检查点，以在超时和崩溃中存活)
+Source: Augment Code
+Why It May Matter: Synchronous execution often fails due to infrastructure timeouts, making persistent state crucial for complex agent workflows. (由于基础设施超时，同步执行经常失败，因此持久状态对于复杂的代理工作流至关重要)
+Uncertainty: Low
 
 NEXT_HANDOFF
 
 写给 H2 的输入提示 (Input prompt for H2):
-INPUT_MISSING
+Please evaluate the impact of the upcoming MCP 2026-07-28 spec update on current agent workflows and evaluate how persistent state management can improve async execution reliability. (请评估即将发布的 MCP 2026-07-28 规范更新对当前代理工作流的影响，并评估持久状态管理如何提高异步执行的可靠性)
 
 指出哪些信号需要明天或今天的 Orient 任务解释 (Which signals need to be interpreted by tomorrow's or today's Orient task):
-INPUT_MISSING
+The specific changes to authentication and session management in the new MCP spec need careful analysis to prepare for the July 28 update. (新 MCP 规范中关于身份验证和会话管理的具体更改需要仔细分析，以准备迎接 7 月 28 日的更新)
+How to implement durable state checkpointing for long-running async agents to avoid timeout failures. (如何为长时间运行的异步代理实现持久的状态检查点，以避免超时失败)
 
 指出哪些信号可能只是噪音 (Which signals might just be noise):
-INPUT_MISSING
+Specific implementation details for Firebase AI Logic might be noise if the current tech stack does not rely on Firebase. (如果当前技术栈不依赖 Firebase，则 Firebase AI Logic 的具体实现细节可能是噪音)
 
 BOUNDARY_CHECK
 


### PR DESCRIPTION
Completed the H1 Daily Signal Observe task for 2026-07-08.
Searched for external signals regarding AI Agents, MCP updates, Google Maps Grounding in Gemini, and Async Agent reliability.
Formatted the output cleanly with the designated H1 template into `horizon-cortex/2026-07-08-H1-signal-observe.md` and ensured full compliance with NO_CHINESE_PERIODS policy.

---
*PR created automatically by Jules for task [11273072982540827398](https://jules.google.com/task/11273072982540827398) started by @lostlight530*