### PR TITLE
Generate H2 Daily Horizon Orient Report 2026-07-09

### DIFF
--- a/horizon-cortex/2026-07-09-H2-horizon-orient.md
+++ b/horizon-cortex/2026-07-09-H2-horizon-orient.md
@@ -1,0 +1,81 @@
+CORTEX_RUN_HEADER
+
+Cortex: horizon-cortex
+Host Repository: welcome-to-github
+Task ID: H2
+Cadence: Daily
+Loop Stage: Orient
+Run Date: 2026-07-09
+Agent: Jules
+Knowledge Source: H1 input + External Web + horizon-cortex local files
+Repository Inspection: NO
+GitHub Actions Inspection: NO
+Write Scope: horizon-cortex only
+Boundary Violation: NO
+
+INPUT_RECORD
+
+记录读取的 H1 文件路径:
+INPUT_MISSING
+
+记录读取的历史 horizon-cortex 文件路径:
+horizon-cortex/2026-07-08-H2-horizon-orient.md
+
+记录本次联网验证的主题和来源:
+Verified "Anthropic Model Context Protocol Edge AI updates July 2026" via external web search (modelcontextprotocol.io).
+
+SIGNAL_CLASSIFICATION
+
+noise:
+Anthropic's redeployment of Claude Fable 5 and related US export control news is currently considered system noise as it does not directly impact the horizon-cortex agent execution or Model Context Protocol standard workflow
+
+weak signal:
+Due to the missing H1 file data, there are no specific weak signals to classify today
+
+strategic signal:
+The 2026-07-28 MCP Specification Release Candidate (stateless core, MCP Apps, Tasks extension) confirms the strategic direction toward long-running agent executions and HTTP-based server-rendered UIs
+
+watchlist:
+The integration patterns of the new MCP Tasks extension and how they map to our Edge AI capabilities remain a watchlist item
+
+ignore:
+General AI news not related to MCP or Edge AI execution workflows
+
+ORIENTATION_NOTES
+
+说明今日信号对 horizon-cortex 自身意味着什么:
+The ongoing validation of the MCP Tasks extension and stateless HTTP core means horizon-cortex must continue prioritizing the observation of long-running agent workflows
+
+说明哪些外部知识会影响未来 Jules 的观察重点:
+Future Jules observations will be heavily influenced by how the MCP Tasks extension is adopted in practice and how it handles asynchronous edge executions
+
+说明哪些判断仍然不确定:
+The adoption rate of the new MCP Tasks extension and its exact impact on existing scheduled execution surfaces remains uncertain
+
+NO_DECISION_SECTION
+
+明确列出今天不做的决策:
+Do not modify any architecture
+Do not adjust monitoring focus
+
+明确列出今天不能修改的内容:
+Do not modify any code or configuration in the host repository
+Do not read GitHub Actions
+Do not write any files outside of horizon-cortex
+
+NEXT_HANDOFF
+
+写给 H3 的周决策输入:
+Reiterate the suggestion to incorporate the new MCP Tasks extension and its implications for long-running agent workflows into the strategic watchlines
+
+列出本周候选方向:
+Research the impact of the MCP stateless core and Tasks extension on scheduled agent execution
+
+列出需要继续观察的信号:
+The rollout of the MCP 2026-07-28 Release Candidate and early adoption patterns of MCP Apps and Tasks
+
+BOUNDARY_CHECK
+
+确认没有读取宿主仓库机制: YES
+确认没有读取 GitHub Actions: YES
+确认没有写入 horizon-cortex 之外的文件: YES


### PR DESCRIPTION
Generated the Daily H2 Horizon Orient report for 2026-07-09, strictly following the provided instructions, formatting templates, and the NO_CHINESE_PERIODS rule. The report properly notes `INPUT_MISSING` for the missing daily H1 report and incorporates external signals verified via web search.

---
*PR created automatically by Jules for task [3613533275522231433](https://jules.google.com/task/3613533275522231433) started by @lostlight530*