### PR TITLE
feat(horizon-cortex): add daily H2 orient report

### DIFF
--- a/horizon-cortex/2026-07-10-H2-horizon-orient.md
+++ b/horizon-cortex/2026-07-10-H2-horizon-orient.md
@@ -1,0 +1,80 @@
+CORTEX_RUN_HEADER
+
+Cortex: horizon-cortex
+Host Repository: welcome-to-github
+Task ID: H2
+Cadence: Daily
+Loop Stage: Orient
+Run Date: 2026-07-10
+Agent: Jules
+Knowledge Source: H1 input + External Web + horizon-cortex local files
+Repository Inspection: NO
+GitHub Actions Inspection: NO
+Write Scope: horizon-cortex only
+Boundary Violation: NO
+
+INPUT_RECORD
+
+记录读取的 H1 文件路径:
+INPUT_MISSING
+
+记录读取的历史 horizon-cortex 文件路径:
+horizon-cortex/2026-07-09-H2-horizon-orient.md
+
+记录本次联网验证的主题和来源:
+INPUT_MISSING
+
+SIGNAL_CLASSIFICATION
+
+noise:
+INPUT_MISSING
+
+weak signal:
+INPUT_MISSING
+
+strategic signal:
+INPUT_MISSING
+
+watchlist:
+INPUT_MISSING
+
+ignore:
+INPUT_MISSING
+
+ORIENTATION_NOTES
+
+说明今日信号对 horizon-cortex 自身意味着什么:
+INPUT_MISSING
+
+说明哪些外部知识会影响未来 Jules 的观察重点:
+INPUT_MISSING
+
+说明哪些判断仍然不确定:
+INPUT_MISSING
+
+NO_DECISION_SECTION
+
+明确列出今天不做的决策:
+由于缺少 H1 输入文件，今天不做出任何决策 (No decisions made today due to missing H1 input)
+
+明确列出今天不能修改的内容:
+不修改任何代码或配置 (Do not modify any code or configuration in the host repository)
+不读取 GitHub Actions (Do not read GitHub Actions)
+不写入 horizon-cortex 之外的任何文件 (Do not write any files outside of horizon-cortex)
+
+NEXT_HANDOFF
+
+写给 H3 的周决策输入:
+INPUT_MISSING
+
+列出本周候选方向:
+INPUT_MISSING
+
+列出需要继续观察的信号:
+INPUT_MISSING
+
+BOUNDARY_CHECK
+
+确认没有读取宿主仓库机制: YES
+确认没有读取 GitHub Actions: YES
+确认没有写入 horizon-cortex 之外的文件: YES


### PR DESCRIPTION
Added the daily H2 report (`2026-07-10-H2-horizon-orient.md`) under `horizon-cortex`. Since no H1 file existed for today, it properly lists `INPUT_MISSING` and makes no decisions. Standard boundary checks and formatting verified.

---
*PR created automatically by Jules for task [10398955996879884258](https://jules.google.com/task/10398955996879884258) started by @lostlight530*