### PR TITLE
Add daily signal observe report for 2026-07-10

### DIFF
--- a/horizon-cortex/2026-07-10-H1-signal-observe.md
+++ b/horizon-cortex/2026-07-10-H1-signal-observe.md
@@ -1,0 +1,104 @@
+CORTEX_RUN_HEADER
+
+Cortex: horizon-cortex
+
+Host Repository: welcome-to-github
+
+Task ID: H1
+
+Cadence: Daily
+
+Loop Stage: Observe
+
+Run Date: 2026-07-10
+
+Agent: Jules
+
+Knowledge Source: External Web + horizon-cortex local files
+
+Repository Inspection: NO
+
+GitHub Actions Inspection: NO
+
+Write Scope: horizon-cortex only
+
+Boundary Violation: NO
+
+INPUT_RECORD
+
+记录本次读取了哪些 horizon-cortex 文件:
+horizon-cortex/2026-07-09-H1-signal-observe.md
+horizon-cortex/2026-07-09-H2-horizon-orient.md
+horizon-cortex/sample-2026-07-01-H1-signal-observe.md
+
+记录本次联网搜索了哪些主题:
+"MCP Model Context Protocol 2026 update", "Google Labs AI Agent Coding Agent 2026"
+
+记录每个主题为什么需要观察:
+根据 H1 任务要求，需要联网观察 AI Agent, MCP, Coding Agent, Google Labs, Agent workflow 等方向的外部新信号，以获取最新的基础设施更新和行业动态.
+
+EXTERNAL_SOURCE_RECORDS
+
+Source 1
+Title: The biggest MCP spec update ships July 28: What changes for AI agent authentication
+Publisher: WorkOS Blog
+URL: https://workos.com/blog/mcp-2026-spec-agent-authentication
+Date Checked: 2026-07-10
+Source Type: Tech Blog
+Relevance: 详细介绍了 MCP 2026-07-28 规范的无状态核心、扩展框架以及授权强化等内容.
+Confidence: High
+
+Source 2
+Title: The 2026-07-28 MCP Specification Release Candidate
+Publisher: Model Context Protocol Blog
+URL: https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/
+Date Checked: 2026-07-10
+Source Type: Official Blog
+Relevance: MCP 官方发布的候选版本说明，确认了协议层会话的移除以及 Tasks 成为正式扩展.
+Confidence: High
+
+Source 3
+Title: Google Jules: Gemini Async Coding Agent Guide 2026
+Publisher: Digital Applied
+URL: https://www.digitalapplied.com/blog/google-jules-gemini-async-coding-agent-guide
+Date Checked: 2026-07-10
+Source Type: Tech Blog
+Relevance: 介绍了来自 Google Labs 的 Jules 异步编码代理，它通过云端 VM 和任务队列工作，并以 Pull Request 形式交付代码.
+Confidence: High
+
+RAW_SIGNAL_LOG
+
+Signal 1
+Signal: MCP 将在 2026-07-28 规范中转向无状态核心，移除初始化握手和 session-id 头部.
+Source: Model Context Protocol Blog & WorkOS Blog
+Why It May Matter: 无状态 MCP 服务器可以更容易地进行负载均衡，这改变了代理连接和多步工作流的维护方式.
+Uncertainty: Low
+
+Signal 2
+Signal: MCP 的 Tasks 功能成为一等公民扩展，同时引入了用于服务器渲染界面的 MCP Apps.
+Source: Model Context Protocol Blog
+Why It May Matter: 这将长时间运行的异步任务转移到了标准扩展中，并提供了明确的生命周期管理机制 (tasks/get, tasks/update, tasks/cancel).
+Uncertainty: Low
+
+Signal 3
+Signal: Google Jules 作为一个异步编码代理，通过任务队列和云端 VM 工作，而不是同步的聊天界面交互.
+Source: Digital Applied
+Why It May Matter: 凸显了行业向异步、批处理、基于 PR 交付的代理工作流转变的趋势，这与 Jules 自身的计划执行模式高度契合.
+Uncertainty: Low
+
+NEXT_HANDOFF
+
+写给 H2 的输入提示:
+请评估 MCP 2026-07-28 的无状态核心与 Tasks 扩展对 horizon-cortex 架构的影响，并分析 Google Jules 的异步任务工作流如何映射到我们当前的执行模型.
+
+指出哪些信号需要明天或今天的 Orient 任务解释:
+MCP 移除协议级会话对边缘执行层的影响，以及 Jules 异步 PR 交付模式是否提供了新的战略方向.
+
+指出哪些信号可能只是噪音:
+有关 OAuth 2.1 客户端注册细节或 MCP Apps 中 UI 渲染的具体实现方式目前可能不会直接影响 horizon-cortex 的后端核心.
+
+BOUNDARY_CHECK
+
+确认没有读取宿主仓库机制: YES
+确认没有读取 GitHub Actions: YES
+确认没有写入 horizon-cortex 之外的文件: YES


### PR DESCRIPTION
This PR adds the daily H1 signal observation report for `2026-07-10` into the `horizon-cortex` directory. It adheres to all constraints, including not touching any repository files or mechanisms outside `horizon-cortex` and properly structuring the data with external sources, raw signals, and handoffs for H2.

---
*PR created automatically by Jules for task [6459196873465523235](https://jules.google.com/task/6459196873465523235) started by @lostlight530*