### PR TITLE
feat(horizon-cortex): add 2026-W28 H4 Narrative Act

### DIFF
--- a/horizon-cortex/2026-W28-H4-narrative-act.md
+++ b/horizon-cortex/2026-W28-H4-narrative-act.md
@@ -1,0 +1,81 @@
+CORTEX_RUN_HEADER
+
+Cortex: horizon-cortex
+Host Repository: welcome-to-github
+Task ID: H4
+Cadence: Weekly
+Loop Stage: Act
+Run Week: 2026-W28
+Agent: Jules
+Knowledge Source: H3 decision + External Web + horizon-cortex local files
+Repository Inspection: NO
+GitHub Actions Inspection: NO
+Write Scope: horizon-cortex only
+Boundary Violation: NO
+
+INPUT_RECORD
+
+记录读取的 H3 文件路径:
+horizon-cortex/2026-W28-H3-position-decide.md
+
+记录读取的辅助 H1 / H2 文件路径:
+horizon-cortex/2026-07-06-H1-signal-observe.md
+horizon-cortex/2026-07-07-H1-signal-observe.md
+horizon-cortex/2026-07-08-H1-signal-observe.md
+horizon-cortex/2026-07-09-H1-signal-observe.md
+horizon-cortex/2026-07-10-H1-signal-observe.md
+horizon-cortex/2026-07-11-H1-signal-observe.md
+horizon-cortex/2026-07-06-H2-horizon-orient.md
+horizon-cortex/2026-07-07-H2-horizon-orient.md
+horizon-cortex/2026-07-08-H2-horizon-orient.md
+horizon-cortex/2026-07-09-H2-horizon-orient.md
+horizon-cortex/2026-07-10-H2-horizon-orient.md
+horizon-cortex/2026-07-11-H2-horizon-orient.md
+horizon-cortex/2026-07-12-H2-horizon-orient.md
+(Note: 2026-07-12-H1-signal-observe.md INPUT_GAP observed in H3)
+horizon-cortex/2026-W27-H3-position-decide.md
+horizon-cortex/2026-W27-H4-narrative-act.md
+horizon-cortex/sample-2026-W27-H3-position-decide.md
+horizon-cortex/sample-2026-07-H6-horizon-memorize.md
+
+记录联网复核来源:
+- MCP Tasks Extension: https://modelcontextprotocol.io/extensions/tasks/overview (Tasks represent durable state machines for long-running workflows).
+- Google Maps Grounding Gemini: Google Cloud Docs & Maps Grounding API details (Integrating geospatial data to reduce context hallucinations).
+- OPAQUE Confidential MCP: OPAQUE 3.0 announcement (Verifiable trust, open governance standards, confidential execution).
+
+ACTION_RECORD
+
+Action 1
+Action: Update strategic watchlines in horizon-cortex to prioritize the MCP 2026-07-28 Tasks extension.
+Reason: The final MCP specification ships on July 28, making it critical to establish integration patterns for long-running asynchronous agent execution.
+Source Decision: Shift architectural focus towards the MCP 2026-07-28 Tasks extension for handling long-running asynchronous agent execution.
+Expected Effect: Internal systems will be prepared for the upcoming MCP spec, enhancing the reliability of asynchronous agent workflows.
+Risk Reduced: Low.
+No Host Repository Change: YES.
+
+Action 2
+Action: Introduce Context Engineering and Spatial Reasoning Grounding as core observation metrics in the horizon-cortex documentation.
+Reason: Agents increasingly rely on specialized data layers (like Google Maps Grounding) to maintain persistent state and accurate context over multi-step reasoning.
+Source Decision: Introduce spatial reasoning grounding and Context Engineering as core observation metrics for agent reliability.
+Expected Effect: Enhances the agent's ability to act on complex, context-heavy tasks over time without hallucinations.
+Risk Reduced: Low.
+No Host Repository Change: YES.
+
+NEXT_WEEK_OPERATING_NOTES
+
+写给下周 H1 / H2 / H3 的运行建议:
+- 重点观察主题 (Focus Topics): Monitor the official release of the MCP 2026-07-28 specification, specifically the Tasks extension and any newly published reference implementations. Continue tracking verifiable AI agent frameworks like OPAQUE Confidential MCP and further developments in Gemini's spatial reasoning (Google Maps Grounding).
+- 需要避免的误判 (Avoid Misjudgments): Avoid general no-code UI builders and generic generative AI news. They are noise compared to our backend automation, edge AI, and asynchronous task orchestration focus.
+- 需要继续验证的来源类型 (Sources to Verify): Official MCP specification repositories (e.g., ext-tasks), Google Cloud documentation regarding agent grounding, and cryptographic governance updates for enterprise agents.
+
+ACTION_LIMITS
+
+明确说明本次没有修改宿主仓库: YES
+明确说明本次没有修改 GitHub Actions: YES
+明确说明本次没有创建非周期文件: YES
+
+BOUNDARY_CHECK
+
+确认没有读取宿主仓库机制: YES
+确认没有读取 GitHub Actions: YES
+确认没有写入 horizon-cortex 之外的文件: YES


### PR DESCRIPTION
This PR introduces the weekly H4 Narrative Act file for `2026-W28`. It reads the decisions from `2026-W28-H3-position-decide.md` and sets up the internal `horizon-cortex` narrative and operational guidelines for the upcoming week, specifically focusing on the newly announced MCP Tasks extension and spatial reasoning (Google Maps Grounding). It adheres strictly to boundary constraints and formatting rules.

---
*PR created automatically by Jules for task [6395452231756376094](https://jules.google.com/task/6395452231756376094) started by @lostlight530*