### PR TITLE
Add H1 Daily Signal Observe Report for 2026-07-12

### DIFF
--- a/horizon-cortex/2026-07-12-H1-signal-observe.md
+++ b/horizon-cortex/2026-07-12-H1-signal-observe.md
@@ -1,0 +1,92 @@
+CORTEX_RUN_HEADER
+
+Cortex: horizon-cortex
+Host Repository: welcome-to-github
+Task ID: H1
+Cadence: Daily
+Loop Stage: Observe
+Run Date: 2026-07-12
+Agent: Jules
+Knowledge Source: External Web + horizon-cortex local files
+Repository Inspection: NO
+GitHub Actions Inspection: NO
+Write Scope: horizon-cortex only
+Boundary Violation: NO
+
+INPUT_RECORD
+
+记录本次读取了哪些 horizon-cortex 文件:
+horizon-cortex/2026-07-11-H1-signal-observe.md
+horizon-cortex/2026-07-12-H2-horizon-orient.md
+
+记录本次联网搜索了哪些主题:
+"AI Agent", "MCP", "Coding Agent", "Google Labs", "Google Maps Grounding", "Gemini / AI Studio", "Open source governance", "Agent workflow", "Async execution", "Developer tooling", "Agent reliability"
+
+记录每个主题为什么需要观察:
+根据 H1 任务要求，需要联网观察以上方向的外部新信号，以获取最新的行业动态与基础设施演进，并服务于 horizon-cortex 后续的定位与决策.
+
+EXTERNAL_SOURCE_RECORDS
+
+Source 1
+Title: X Launches Hosted MCP: AI Agents Get Real-Time Data - Enterprise DNA
+Publisher: Enterprise DNA
+URL: https://enterprisedna.co/resources/news/x-twitter-hosted-mcp-ai-agents-realtime-data-2026/
+Date Checked: 2026-07-12
+Source Type: News / Tech Blog
+Relevance: 介绍了 X 发布的托管 MCP 服务器，允许 AI Agent 实时读取 X 数据，极大降低了集成成本.
+Confidence: High
+
+Source 2
+Title: I/O 2026 developer highlights: Antigravity, Gemini API, AI Studio - Google Blog
+Publisher: Google Blog
+URL: https://blog.google/innovation-and-ai/technology/developers-tools/google-io-2026-developer-highlights/
+Date Checked: 2026-07-12
+Source Type: Official Blog
+Relevance: 介绍了 Google Antigravity 2.0、Gemini API 中的托管 Agent 以及 AI Studio 中的本地 Android vibe 编码，预示着基于 Agent 的开发工具新生态.
+Confidence: High
+
+Source 3
+Title: Best AI agent reliability tools (2026): ship agents that don't fail in production - Braintrust
+Publisher: Braintrust
+URL: https://www.braintrust.dev/articles/best-ai-agent-reliability-tools-2026
+Date Checked: 2026-07-12
+Source Type: Tech Article / Product Review
+Relevance: 对比了 2026 年的 AI 代理可靠性工具，讨论了部署前评估、生产观察性和回归调试.
+Confidence: High
+
+RAW_SIGNAL_LOG
+
+Signal 1
+Signal: X 推出官方托管 MCP 服务器，提供 200 多种工具，代理可实时读取数据并与 Grok, Cursor, Claude Desktop 等无缝对接.
+Source: Enterprise DNA
+Why It May Matter: 这标志着主流社交媒体和数据源直接通过 MCP 向代理开放，打破了传统的 API 限制，使实时市场情报获取变得极其简单.
+Uncertainty: Low
+
+Signal 2
+Signal: Google 推出 Antigravity 2.0，这是一个 Agent 优先的开发平台，并且在 Gemini API 中加入了托管的代理功能.
+Source: Google Blog
+Why It May Matter: Google 正在全面构建代理基础设施，从无基础设施搭建（Managed Agents）到全生命周期的代理开发平台，极大降低了构建生产级代理应用的门槛.
+Uncertainty: Low
+
+Signal 3
+Signal: 针对 AI 代理的生产可靠性工具生态正在成熟，包括 Braintrust, Galileo, Arize Phoenix 等.
+Source: Braintrust
+Why It May Matter: 随着代理部署到生产环境，可靠性、回归测试和监控成为基础设施的核心环节，这也是我们在构建复杂代理工作流时必须考虑的防御性工程.
+Uncertainty: Low
+
+NEXT_HANDOFF
+
+写给 H2 的输入提示:
+请评估 X 托管 MCP 的引入如何影响我们的外部信号获取策略，以及 Google Antigravity/Managed Agents 对现有代理架构的启示. 同时评估是否需要引入更专业的可靠性工具.
+
+指出哪些信号需要明天或今天的 Orient 任务解释:
+X 托管 MCP 的实时数据读取能力能否被低成本整合进我们现有的观察回路中.
+
+指出哪些信号可能只是噪音:
+具体平台（如 Braintrust 或 Galileo）的功能对比细节在现阶段可能是噪音，只需关注可靠性工具的发展趋势.
+
+BOUNDARY_CHECK
+
+确认没有读取宿主仓库机制: YES
+确认没有读取 GitHub Actions: YES
+确认没有写入 horizon-cortex 之外的文件: YES


### PR DESCRIPTION
Generates the H1 Daily Signal Observe markdown report for 2026-07-12. The data is pulled from recent external news, correctly formatted under strict task directives without accessing out-of-bounds resources. Punctuation has been normalized to English periods.

---
*PR created automatically by Jules for task [4164073319276802315](https://jules.google.com/task/4164073319276802315) started by @lostlight530*