### PR TITLE
docs(horizon-cortex): add 2026-07-13 H1 signal observe report

### DIFF
--- a/horizon-cortex/2026-07-13-H1-signal-observe.md
+++ b/horizon-cortex/2026-07-13-H1-signal-observe.md
@@ -1,0 +1,160 @@
+CORTEX_RUN_HEADER
+
+Cortex: horizon-cortex
+Host Repository: welcome-to-github
+Task ID: H1
+Cadence: Daily
+Loop Stage: Observe
+Run Date: 2026-07-13
+Agent: Jules
+Knowledge Source: External Web + horizon-cortex local files
+Repository Inspection: NO
+GitHub Actions Inspection: NO
+Write Scope: horizon-cortex only
+Boundary Violation: NO
+
+INPUT_RECORD
+
+记录本次读取了哪些 horizon-cortex 文件:
+horizon-cortex/2026-07-12-H1-signal-observe.md
+horizon-cortex/2026-07-12-H2-horizon-orient.md
+
+记录本次联网搜索了哪些主题:
+"AI Agents" "July 2026", "Google Labs" "July 2026", "MCP" "July 2026", "Coding Agent" "July 2026", "Model Context Protocol", "Developer tooling", "Agent reliability", "Async execution", "Agent workflow"
+
+记录每个主题为什么需要观察:
+根据 H1 任务要求，需要联网观察以上方向的外部新信号，以获取最新的行业动态与基础设施演进，并服务于 horizon-cortex 后续的定位与决策
+
+EXTERNAL_SOURCE_RECORDS
+
+Source 1
+Title: Best AI Coding Agent 2026: Why Top Devs Run Two
+Publisher: AI Builder Club
+URL: https://www.aibuilderclub.com/blog/best-ai-coding-agent-2026
+Date Checked: 2026-07-13
+Source Type: Tech Blog
+Relevance: 提到了 Jules，Google 的异步编码 Agent，它能从 GitHub Issues 直接发布 PR
+Confidence: Medium
+
+Source 2
+Title: Enterprise AI Relies on Connectivity: Why Model Context Protocol (MCP) Matters
+Publisher: Decisions Blog
+URL: https://decisions.com/blog/enterprise-ai-relies-on-connectivity-why-model-context-protocol-mcp-matters
+Date Checked: 2026-07-13
+Source Type: Enterprise Blog
+Relevance: 强调了 MCP 作为企业 AI 与外部工具交互的开放标准的重要性
+Confidence: High
+
+Source 3
+Title: AI Weekly: New PC Chips, Credit Pricing, Stateless MCP
+Publisher: DEV Community
+URL: https://dev.to/alexmercedcoder/ai-weekly-new-pc-chips-credit-pricing-stateless-mcp-1eb9
+Date Checked: 2026-07-13
+Source Type: Community Post
+Relevance: 讨论了 MCP 向无状态核心的演进（2025 年 6 月更新和未来的无状态更新），以支持企业级水平扩展
+Confidence: High
+
+Source 4
+Title: MCP Goes Stateless: What the 2026 Spec Means for SMEs
+Publisher: Crux Digits
+URL: https://cruxdigits.nl/blog/mcp-goes-stateless-2026-spec/
+Date Checked: 2026-07-13
+Source Type: Tech Blog
+Relevance: 2026 年 7 月 28 日的 MCP 规范将使协议变为无状态，使中小型企业能够利用普通 HTTP 托管和负载均衡器运行 Agent 集成
+Confidence: High
+
+Source 5
+Title: JetStream Launches Verified MCP Governance Layer for Enterprise AI Agents
+Publisher: Access Newswire
+URL: https://www.accessnewswire.com/newsroom/en/computers-technology-and-internet/jetstream-launches-verified-mcp-governance-layer-for-enterprise-a-1190088
+Date Checked: 2026-07-13
+Source Type: Press Release
+Relevance: JetStream Security 推出新的 MCP 治理和验证平台（2026 年 7 月 13 日）
+Confidence: High
+
+Source 6
+Title: Google Release Notes - July 2026 Latest Updates
+Publisher: Releasebot
+URL: https://releasebot.io/updates/google
+Date Checked: 2026-07-13
+Source Type: Release Notes Tracker
+Relevance: 介绍了 Gemini Enterprise Agent Platform 在 2026 年 7 月添加了 Memory Bank 支持和 IngestEvents API GA 版本，同时弃用了 Grok 4.1 模型
+Confidence: High
+
+Source 7
+Title: Building Semi-Autonomous Coding Agents on Amazon Bedrock AgentCore
+Publisher: AWS Experience
+URL: https://aws-experience.com/amer/smb/e/525d0/agent-platform-cost-savings-and-attribution-best-practices
+Date Checked: 2026-07-13
+Source Type: Official AWS Event
+Relevance: 描述了一个研讨会，教授在 AWS 基础设施上部署平行、可治理的代码 Agent，重点是确定性测试而不是 LLM 评估
+Confidence: High
+
+Source 8
+Title: Workday Launches New Tools for Developers to Build, Connect, and Verify AI Agents
+Publisher: Stock Titan
+URL: https://www.stocktitan.net/news/WDAY/workday-launches-new-tools-for-developers-to-build-connect-and-qwcgs5hrpumv.html
+Date Checked: 2026-07-13
+Source Type: Financial / Tech News
+Relevance: Workday 推出 Developer Agent，支持通过 MCP 访问，并集成了如 Google Antigravity 等工具
+Confidence: High
+
+Source 9
+Title: What we know about Grok Build in July 2026
+Publisher: Reddit (r/AgentContext_dev)
+URL: https://www.reddit.com/r/AgentContext_dev/comments/1uv6oi7/what_we_know_about_grok_build_in_july_2026/
+Date Checked: 2026-07-13
+Source Type: Social Media / Developer Discussion
+Relevance: 提供了 xAI's Grok Build 在 2026 年 7 月的状态更新，特别提到了它的 "/goal" 模式和真正的并行多工作树子代理执行
+Confidence: Medium
+
+RAW_SIGNAL_LOG
+
+Signal 1
+Signal: MCP 将在 2026 年 7 月 28 日迎来大规模更新，正式转变为无状态协议
+Source: DEV Community / Crux Digits
+Why It May Matter: 这将消除以前因为有状态会话而产生的可扩展性问题，让基于 HTTP 的简单负载均衡成为可能，极大地促进了在企业和中小企业中的使用
+Uncertainty: Low
+
+Signal 2
+Signal: Google 的异步编码 Agent "Jules" 被外界评价为 Devin 的竞争者，能够从 GitHub Issues 交付 PR
+Source: AI Builder Club
+Why It May Matter: 展示了异步执行 Agent 正在成为主流的代码生成工具
+Uncertainty: Low
+
+Signal 3
+Signal: JetStream 和 Workday 相继推出企业级 MCP 验证与治理工具
+Source: Access Newswire / Stock Titan
+Why It May Matter: 随着 MCP 被广泛采用，围绕它的安全、合规和验证生态正在迅速成熟
+Uncertainty: Low
+
+Signal 4
+Signal: Gemini Enterprise Agent Platform 在 2026 年 7 月支持了 Memory Bank 和 IngestEvents API GA
+Source: Releasebot
+Why It May Matter: 使得流式事件处理和长期记忆修订成为平台原生能力
+Uncertainty: Low
+
+Signal 5
+Signal: AWS Bedrock AgentCore 和 Grok Build 强调并行 Agent 的执行与确定性测试，支持多工作树管理
+Source: AWS Experience / Reddit
+Why It May Matter: 异步执行与多 Agent 并行竞争/协作模式正在向标准化发展，有助于突破单体 Agent 效率瓶颈
+Uncertainty: Medium
+
+NEXT_HANDOFF
+
+写给 H2 的输入提示:
+请评估 MCP 2026 年 7 月下旬的无状态更新以及 JetStream 治理平台对当前架构和代理集成策略的影响
+分析真正的并行/多工作树代理（如 Grok Build 和 AWS 的实验）在代码代理领域的潜力
+
+指出哪些信号需要明天或今天的 Orient 任务解释:
+"Jules" 异步功能的外部认知是否与我们预期的一致
+Gemini 的 Memory Bank 更新对状态维护的启示
+
+指出哪些信号可能只是噪音:
+部分针对非核心工具（如某些独立的评测数据和特定的产品营销包装）可暂时视为噪音
+
+BOUNDARY_CHECK
+
+确认没有读取宿主仓库机制: YES
+确认没有读取 GitHub Actions: YES
+确认没有写入 horizon-cortex 之外的文件: YES


### PR DESCRIPTION
This pull request adds the H1 Daily Signal Observe report for the date `2026-07-13` into the `horizon-cortex` directory. It strictly follows the H1 loop instructions, avoiding any external modifications to host repository files, reading only relevant H1/H2 local state context, and compiling a formatted report based on extensive web research.

The PR includes:
- Thorough web search results about MCP 2026 Stateless updates, Jules coding agent, Google Labs/Gemini Memory Bank API updates, and multi-agent AWS Bedrock / Grok Build updates.
- Formatting the signal log with all requested headings correctly.
- Post-processing to enforce the NO_CHINESE_PERIODS standard in all drafted text.

---
*PR created automatically by Jules for task [7342376092442427909](https://jules.google.com/task/7342376092442427909) started by @lostlight530*