### PR TITLE
feat(cortex): execute H1 daily signal observe for 2026-07-14

### DIFF
--- a/horizon-cortex/2026-07-14-H1-signal-observe.md
+++ b/horizon-cortex/2026-07-14-H1-signal-observe.md
@@ -1,0 +1,96 @@
+CORTEX_RUN_HEADER
+
+Cortex: horizon-cortex
+Host Repository: welcome-to-github
+Task ID: H1
+Cadence: Daily
+Loop Stage: Observe
+Run Date: 2026-07-14
+Agent: Jules
+Knowledge Source: External Web + horizon-cortex local files
+Repository Inspection: NO
+GitHub Actions Inspection: NO
+Write Scope: horizon-cortex only
+Boundary Violation: NO
+
+INPUT_RECORD
+
+记录本次读取了哪些 horizon-cortex 文件:
+horizon-cortex/2026-07-13-H2-horizon-orient.md
+
+记录本次联网搜索了哪些主题:
+"MCP" "AI Agent" OR "Coding Agent" OR "Agent workflow"
+"Google Labs" "Agent" OR "Gemini" OR "AI Studio"
+
+记录每个主题为什么需要观察:
+MCP 正在成为 AI Agent 访问外部系统的标准协议，并且 Oracle 的 Fusion AI Agent Studio 已经开始集成，了解其进展有助于理解生态的演变.
+Google Labs 推出了新的 Gemini Agent 及其工具链，包括 Gemini Spark，观察其 agentic 能力有助于把握 AI 助手和自动化流程的趋势.
+
+EXTERNAL_SOURCE_RECORDS
+
+Title: MCP Tool in AI Agent Studio | fusioncoe - Oracle Blogs
+Publisher: Oracle Blogs
+URL: https://blogs.oracle.com/fusioncoe/mcp-tool-in-ai-agent-studio
+Date Checked: 2026-07-14
+Source Type: Blog
+Relevance: High
+Confidence: High
+
+Title: AI agent vs MCP: how they differ and overlap - Merge.dev
+Publisher: Merge.dev
+URL: https://www.merge.dev/blog/ai-agent-vs-mcp
+Date Checked: 2026-07-14
+Source Type: Blog
+Relevance: High
+Confidence: High
+
+Title: The Gemini app becomes more agentic, delivering proactive, 24/7 help - Google Blog
+Publisher: Google Blog
+URL: https://blog.google/innovation-and-ai/products/gemini-app/next-evolution-gemini-app/
+Date Checked: 2026-07-14
+Source Type: Blog
+Relevance: High
+Confidence: High
+
+Title: Start building - Google AI
+Publisher: Google AI
+URL: https://ai.google/build/
+Date Checked: 2026-07-14
+Source Type: Website
+Relevance: High
+Confidence: High
+
+RAW_SIGNAL_LOG
+
+Signal: Fusion AI Agent Studio 引入了对 MCP 的支持，使得开发者能直接将 AI Agent 连接到兼容 MCP 的服务器，无需为每次集成构建自定义 API.
+Source: Oracle Blogs (MCP Tool in AI Agent Studio)
+Why It May Matter: 这表明 MCP 作为系统集成的标准正在被大型企业级平台所接受，提升了扩展性和维护性.
+Uncertainty: 企业级系统完全过渡到 MCP 的速度和具体的兼容性挑战尚不明确.
+
+Signal: Google 推出了 Gemini Spark，这是一个 24/7 个人 AI Agent，并将在 MacOS 桌面应用中集成，以便在本地机器上运行.
+Source: Google Blog (The Gemini app becomes more agentic)
+Why It May Matter: 这显示出将 AI Agent 从云端向端侧（特别是本地操作系统层面）深度整合的趋势，与我们关注的端侧 AI 策略不谋而合.
+Uncertainty: 这种本地集成的具体性能表现和系统权限开放程度尚待观察.
+
+Signal: Google 发布了 Google Antigravity，一个以 Agent 为先的开发平台.
+Source: Google AI
+Why It May Matter: 大型科技公司正在构建专门的平台级工具来支持 Agent 工作流的开发，这将加速整个生态的繁荣.
+Uncertainty: Antigravity 的具体功能细节和开发者接受度尚未可知.
+
+NEXT_HANDOFF
+
+写给 H2 的输入提示:
+H2 需要解释 Oracle Fusion 引入 MCP 的动作是否意味着 MCP 已经成熟到可以作为企业级 Agent 架构的标准层，以及 Google 新的 Antigravity 平台和 Gemini Spark 对端侧 Agent 部署路径的启示.
+
+指出哪些信号需要明天或今天的 Orient 任务解释:
+Oracle 和其他大厂在 MCP 支持上的跟进速度.
+Google Antigravity 平台的具体架构定位.
+
+指出哪些信号可能只是噪音:
+关于 Gemini UI 设计语言 (Neural Expressive) 的更新可能是噪音.
+
+BOUNDARY_CHECK
+
+确认没有读取宿主仓库机制: YES
+确认没有读取 GitHub Actions: YES
+确认没有写入 horizon-cortex 之外的文件: YES


### PR DESCRIPTION
Executed the H1 Daily Signal Observe task for 2026-07-14. This included writing a structured observation markdown file to `horizon-cortex/2026-07-14-H1-signal-observe.md` after fetching recent news about MCP, Oracle Fusion AI Agent Studio, and Google's Gemini Agent / Antigravity updates. It respects all repository boundaries and strictly follows the NO_CHINESE_PERIODS rule.

---
*PR created automatically by Jules for task [10612517533344563791](https://jules.google.com/task/10612517533344563791) started by @lostlight530*