### PR TITLE
chore(horizon-cortex): add H2 daily orient for 2026-07-19

### DIFF
--- a/horizon-cortex/2026-07-19-H2-horizon-orient.md
+++ b/horizon-cortex/2026-07-19-H2-horizon-orient.md
@@ -1,0 +1,47 @@
+H2 Daily Horizon Orient
+
+CORTEX_RUN_HEADER
+
+Cortex: horizon-cortex
+Host Repository: welcome-to-github
+Task ID: H2
+Cadence: Daily
+Loop Stage: Orient
+Run Date: 2026-07-19
+Agent: Jules
+Knowledge Source: H1 input + External Web + horizon-cortex local files
+Repository Inspection: NO
+GitHub Actions Inspection: NO
+Write Scope: horizon-cortex only
+Boundary Violation: NO
+
+INPUT_RECORD
+
+INPUT_MISSING
+
+SIGNAL_CLASSIFICATION
+
+INPUT_MISSING
+
+ORIENTATION_NOTES
+
+INPUT_MISSING
+
+NO_DECISION_SECTION
+
+INPUT_MISSING
+
+NEXT_HANDOFF
+
+INPUT_MISSING
+
+BOUNDARY_CHECK
+
+确认没有读取宿主仓库机制
+YES
+
+确认没有读取 GitHub Actions
+YES
+
+确认没有写入 horizon-cortex 之外的文件
+YES


### PR DESCRIPTION
Creates the H2 Daily Horizon Orient file for 2026-07-19.
- Verified missing H1 file.
- Used `INPUT_MISSING` for observational data fields as required.
- Included exact requested sections.
- Verified absence of Chinese periods.

---
*PR created automatically by Jules for task [1037865787157657865](https://jules.google.com/task/1037865787157657865) started by @lostlight530*