### PR TITLE
Add 2026-W29 H4 Weekly Narrative Act File

### DIFF
--- a/horizon-cortex/2026-W29-H4-narrative-act.md
+++ b/horizon-cortex/2026-W29-H4-narrative-act.md
@@ -1,0 +1,41 @@
+CORTEX_RUN_HEADER
+Cortex: horizon-cortex
+Host Repository: welcome-to-github
+Task ID: H4
+Cadence: Weekly
+Loop Stage: Act
+Run Week: 2026-W29
+Agent: Jules
+Knowledge Source: H3 decision + External Web + horizon-cortex local files
+Repository Inspection: NO
+GitHub Actions Inspection: NO
+Write Scope: horizon-cortex only
+Boundary Violation: NO
+
+INPUT_RECORD
+- 记录读取的 H3 文件路径：DECISION_INPUT_MISSING
+- 记录读取的辅助 H1 / H2 文件路径：无
+- 记录联网复核来源：无
+
+ACTION_RECORD
+Action: 无
+Reason: DECISION_INPUT_MISSING
+Source Decision: 无
+Expected Effect: 无
+Risk Reduced: 无
+No Host Repository Change: 是
+
+NEXT_WEEK_OPERATING_NOTES
+下周重点观察主题：继续监测前沿生态.
+下周需要避免的误判：避免在缺乏H3输入时盲目行动.
+下周需要继续验证的来源类型：官方白名单生态更新.
+
+ACTION_LIMITS
+本次没有修改宿主仓库.
+本次没有修改 GitHub Actions.
+本次没有创建非周期文件.
+
+BOUNDARY_CHECK
+确认没有读取宿主仓库机制.
+确认没有读取 GitHub Actions.
+确认没有写入 horizon-cortex 之外的文件.


### PR DESCRIPTION
Created `horizon-cortex/2026-W29-H4-narrative-act.md` to fulfill the Weekly Narrative Act task. Properly handled the missing `H3` input file by logging `DECISION_INPUT_MISSING` and appropriately filling default values across all required sections. Ensured compliance with the `NO_CHINESE_PERIODS` policy.

---
*PR created automatically by Jules for task [4224881203584588043](https://jules.google.com/task/4224881203584588043) started by @lostlight530*