### PR TITLE
docs: execute H1 Daily Signal Observe task for 2026-07-20

### DIFF
--- a/horizon-cortex/2026-07-20-H1-signal-observe.md
+++ b/horizon-cortex/2026-07-20-H1-signal-observe.md
@@ -15,20 +15,45 @@ Boundary Violation: NO
 
 INPUT_RECORD
 - Run Date: 2026-07-20
-- Task: Gather raw signals for edge AI practitioners.
+- Tasks: Observe new signals regarding AI Agent, MCP, Coding Agent, Google Labs, Google Maps Grounding, Gemini / AI Studio, Open source governance, Agent workflow, Async execution, Developer tooling, and Agent reliability.
+- Input Files Read: horizon-cortex/2026-07-19-H1-signal-observe.md, horizon-cortex/2026-07-19-H2-horizon-orient.md
+- External Topics Searched: "AI Agent" OR "Model Context Protocol" OR "Google Vertex AI" OR "Gemini 1.5" OR "Coding Agent" OR "Agent workflow"
+- Reason for Observation: To gather new signals for Edge AI Practitioners, specifically concerning MCP (Model Context Protocol) and coding agents.
 
 EXTERNAL_SOURCE_RECORDS
-- [https://github.com/modelcontextprotocol/servers]
-- [https://www.mindspore.cn/en]
+- Title: What is Model Context Protocol (MCP)? A guide
+- Publisher: Google Cloud
+- URL: https://cloud.google.com/discover/what-is-model-context-protocol
+- Date Checked: 2026-07-20
+- Source Type: Official Documentation
+- Relevance: High
+- Confidence: High
+
+- Title: Set up your coding assistant with Gemini MCP and Skills
+- Publisher: Google AI for Developers
+- URL: https://ai.google.dev/gemini-api/docs/coding-agents
+- Date Checked: 2026-07-20
+- Source Type: Official Documentation
+- Relevance: High
+- Confidence: High
 
 RAW_SIGNAL_LOG
-- Signal A: The Model Context Protocol repository managed by Anthropic encourages community server contributions. (由 Anthropic 管理的模型上下文协议存储库鼓励社区贡献服务器)
-- Signal B: MindSpore's open AI framework highlights tight integration with Ascend processors for all scenarios. (MindSpore 的开放 AI 框架强调与适用于所有场景的 Ascend 处理器紧密集成)
+- Signal A: The Model Context Protocol (MCP), introduced by Anthropic in November 2024, provides a secure and standardized language for LLMs to communicate with external data, applications, and services. It acts as a bridge, allowing AI to retrieve current information and take action.
+- Source: Google Cloud - What is Model Context Protocol (MCP)?
+- Why It May Matter: MCP is becoming the open standard for connecting AI agents to external contexts, which is crucial for building reliable and dynamic agent workflows.
+- Uncertainty: Low
+
+- Signal B: Google recommends setting up the Gemini Docs MCP and enhancing environments with Gemini API Skills to keep coding assistants current with the evolving Gemini API. The Gemini public MCP server is available at https://gemini-api-docs-mcp.dev .
+- Source: Google AI for Developers - Set up your coding assistant with Gemini MCP and Skills
+- Why It May Matter: This allows coding agents to access real-time API definitions and integration patterns from official Gemini documentation, addressing the limitation of training data cut-offs.
+- Uncertainty: Low
 
 NEXT_HANDOFF
-Proceed to H2 Daily Horizon Orient task.
+- The H2 Orient task needs to explain the implications of standardizing on MCP for AI agent development, especially in the context of Google's ecosystem (Gemini Docs MCP).
+- Evaluate how the Gemini API Skills can be integrated into future agent workflows to improve reliability and up-to-date knowledge.
+- Neither Signal A nor Signal B appears to be noise; both represent structural developments in the AI Agent ecosystem.
 
 BOUNDARY_CHECK
-Confirmed no read of host repository.
-Confirmed no read of GitHub Actions.
-Confirmed write restricted to horizon-cortex.
+- Confirmed no read of host repository (.github, docs, src, data, README).
+- Confirmed no read of GitHub Actions.
+- Confirmed write restricted to horizon-cortex only.


### PR DESCRIPTION
This PR executes the "H1 Daily Signal Observe" task for 2026-07-20.

Changes:
- Creates `horizon-cortex/2026-07-20-H1-signal-observe.md` after gathering external signals on MCP and Coding Agents.
- Strictly adheres to the required markdown format (`CORTEX_RUN_HEADER`, `INPUT_RECORD`, `EXTERNAL_SOURCE_RECORDS`, `RAW_SIGNAL_LOG`, `NEXT_HANDOFF`, `BOUNDARY_CHECK`).
- Complies with boundary restrictions: no read of `.github`, `docs`, `src`, `data`, `README`, or GitHub Actions.
- Enforces the `NO_CHINESE_PERIODS` policy using `sed`.
- Next handoff evaluates if signals might be noise as explicitly requested.

---
*PR created automatically by Jules for task [15804729306563981890](https://jules.google.com/task/15804729306563981890) started by @lostlight530*