### PR TITLE
fix lifecycle ledger invariants

### DIFF
--- a/.github/workflows/nexus-life-cycle.yml
+++ b/.github/workflows/nexus-life-cycle.yml
@@ -57,6 +57,8 @@ jobs:
         run: python docs/brain/nexus.py evolve
       - name: Render Human-Readable Reports
         run: python docs/brain/report_hygiene.py welcome docs/brain/memories
+      - name: Validate Post-Evolution Graph
+        run: python -c "import sys; sys.path.insert(0, 'docs/brain'); from document_hygiene import canonicalize_ledger; post=canonicalize_ledger('docs/brain/knowledge'); print(post); assert post['duplicate_entities']==0 and post['duplicate_relations']==0 and post['dangling_relations']==0"
       - name: Final Verification
         run: python -m unittest discover -s tests -p 'test*.py'
       - name: Sync World-Line

--- a/docs/brain/cortex.py
+++ b/docs/brain/cortex.py
@@ -250,10 +250,18 @@ class Cortex:
         try:
             orphans = self.get_orphans(limit=10)
             if not orphans: return
+            target_id = "concept_nexus_system"
+            target = self.conn.execute(
+                "SELECT 1 FROM entities WHERE id = ? AND invalid_at IS NULL",
+                (target_id,),
+            ).fetchone()
+            if target is None:
+                self.add_entity(target_id, "concept", "NEXUS System", "Deterministic graph root")
             for orphan in orphans:
                 self.connect_entities(orphan['id'], 'is_capability_of', 'concept_nexus_system', "Auto-sutured ghost node / 自动缝合的幽灵节点", save_to_disk=True)
         except Exception as e:
             print(f"[Cortex Error | 皮质层错误] Orphan suturing failed / 孤立节点缝合失败: {str(e)}")
+            raise
 
     def get_stats(self):
         cursor = self.conn.cursor()

--- a/docs/brain/document_hygiene.py
+++ b/docs/brain/document_hygiene.py
@@ -193,6 +193,8 @@ def _normalize_record(item: dict) -> dict:
         record["dst"] = record.pop("target")
     if "relation" not in record and "rel" in record:
         record["relation"] = record.pop("rel")
+    if "desc" not in record and "description" in record:
+        record["desc"] = record.pop("description")
     if "desc" not in record and "context" in record:
         record["desc"] = record.pop("context")
     return record

--- a/tests/test_harvester.py
+++ b/tests/test_harvester.py
@@ -4,9 +4,10 @@ import tempfile
 import unittest
 import urllib.error
 from pathlib import Path
-from unittest.mock import call, patch
+from unittest.mock import Mock, call, patch
 
 sys.path.insert(0, str(Path(__file__).parents[1] / "docs" / "brain"))
+from cortex import Cortex
 from harvester import Harvester
 from evolution import Evolver
 from scholar import Scholar
@@ -84,6 +85,50 @@ class HarvesterContracts(unittest.TestCase):
             self.assertTrue(contract.exists())
             self.assertFalse(incoming.exists())
             self.assertEqual(len(list((inputs / "archive").rglob("incoming.md"))), 1)
+
+    def test_orphan_suturing_creates_its_target_entity(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cortex = Cortex(root / "cortex.db")
+            try:
+                cortex.add_entity("orphan", "concept", "Orphan", "Isolated")
+
+                cortex.suture_orphans()
+
+                target = cortex.conn.execute(
+                    "SELECT 1 FROM entities WHERE id = ? AND invalid_at IS NULL",
+                    ("concept_nexus_system",),
+                ).fetchone()
+                dangling = cortex.conn.execute(
+                    """
+                    SELECT COUNT(*) FROM relations r
+                    LEFT JOIN entities src ON src.id = r.source AND src.invalid_at IS NULL
+                    LEFT JOIN entities dst ON dst.id = r.target AND dst.invalid_at IS NULL
+                    WHERE r.invalid_at IS NULL AND (src.id IS NULL OR dst.id IS NULL)
+                    """
+                ).fetchone()[0]
+                self_loop = cortex.conn.execute(
+                    """
+                    SELECT COUNT(*) FROM relations
+                    WHERE source = ? AND target = ? AND invalid_at IS NULL
+                    """,
+                    ("concept_nexus_system", "concept_nexus_system"),
+                ).fetchone()[0]
+                self.assertIsNotNone(target)
+                self.assertEqual(dangling, 0)
+                self.assertEqual(self_loop, 0)
+            finally:
+                cortex.conn.close()
+
+    def test_orphan_suturing_propagates_write_failure(self):
+        cortex = Cortex.__new__(Cortex)
+        cortex.get_orphans = lambda limit=10: [{"id": "orphan"}]
+        cortex.conn = Mock()
+        cortex.conn.execute.return_value.fetchone.return_value = (1,)
+
+        with patch.object(cortex, "connect_entities", side_effect=RuntimeError("write failed")):
+            with self.assertRaisesRegex(RuntimeError, "write failed"):
+                cortex.suture_orphans()
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_harvester_readability.py
+++ b/tests/test_harvester_readability.py
@@ -89,6 +89,30 @@ class ReadabilityContracts(unittest.TestCase):
             self.assertEqual(result["entities"], 2)
             self.assertEqual(result["relations"], 1)
 
+    def test_canonicalization_normalizes_description_alias(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            entities = root / "entities"
+            entities.mkdir()
+            (entities / "tech.jsonl").write_text(
+                json.dumps(
+                    {
+                        "id": "model-context-protocol",
+                        "type": "tech",
+                        "name": "Model Context Protocol",
+                        "description": "Tool integration protocol",
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            canonicalize_ledger(root)
+
+            record = json.loads((entities / "tech.jsonl").read_text(encoding="utf-8"))
+            self.assertEqual(record["desc"], "Tool integration protocol")
+            self.assertNotIn("description", record)
+
     def test_truncated_tree_is_a_hard_failure(self):
         harvester = Harvester.__new__(Harvester)
         harvester.state = {"repositories": {}}


### PR DESCRIPTION
## Root cause

The lifecycle canonicalized the graph before evolution, but `suture_orphans()` then wrote relations to a missing `concept_nexus_system` target and swallowed write failures. The active ledger also contained entity records using `description` while rebuild expects `desc`.

## Scope

- create the deterministic root entity only when there are original orphans, then connect those orphans without introducing a root self-loop
- propagate suturing failures so Actions cannot report a false success
- normalize `description` to the canonical `desc` field
- validate graph invariants again after evolution
- add focused regression coverage

No frontend, sealed archive, Jules-managed directory, or generated ledger file is modified.

## Verification

- workflow-equivalent syntax compilation: 12 lifecycle Python files
- `python -m unittest discover -s tests -v`: 17 tests passed
- `git diff --check`: passed
- remote comparison: 1 commit ahead, 0 behind, exactly 5 approved files

## Risk and rollback

On the next lifecycle, canonicalization may remove the 10 currently dangling active relations and evolution may recreate them against the valid root. Sealed history is untouched. Roll back by reverting this single commit or closing this draft PR.