### PR TITLE
fix: honor versioned harvester state during report rendering

### DIFF
--- a/docs/brain/reason.py
+++ b/docs/brain/reason.py
@@ -149,6 +149,31 @@ class ReasoningEngine:
 
         return "\n".join(hub_lines)
 
+    @staticmethod
+    def _read_harvester_releases(state_file):
+        """Read release metadata from the current versioned Harvester state."""
+        import json
+
+        with open(state_file, 'r', encoding='utf-8') as sf:
+            state_data = json.load(sf)
+
+        if not isinstance(state_data, dict):
+            raise ValueError("harvester state must be a JSON object")
+
+        repositories = state_data.get('repositories')
+        if not isinstance(repositories, dict):
+            raise ValueError("harvester state repositories must be a JSON object")
+
+        releases = []
+        for repo, info in repositories.items():
+            if not isinstance(info, dict):
+                raise ValueError(f"harvester repository state must be a JSON object: {repo}")
+            tag = info.get('last_tag')
+            updated_at = info.get('updated_at') or info.get('last_checked_at')
+            if tag:
+                releases.append(f"- **{repo}** @ `{tag}` (Last Updated: {updated_at})")
+        return releases
+
     def _render_daily_archives(self, metrics: dict, isolated_nodes: list):
         """Phase VI: Hardcore Quantitative Dashboard Rendering (Zero-Dependency)."""
         import os
@@ -311,27 +336,15 @@ class ReasoningEngine:
             pagerank_str = f"**Cognitive Hub (PageRank)**: `{pagerank_hub}`" if pagerank_hub else "Cognitive Hub: Pending inference. / 等待推演。"
 
             # Read Harvester State to dynamically render New Releases and Commits
-            import json
             state_file = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'brain', 'inputs', '.harvester_state.json')
             new_releases_str = "Awaiting native Harvester ingestion cycle. / 等待原生收割机吞噬周期。"
             recent_commits_str = "Awaiting repository sync. / 等待代码库同步。"
 
             if os.path.exists(state_file):
-                try:
-                    with open(state_file, 'r', encoding='utf-8') as sf:
-                        state_data = json.load(sf)
-                        releases = []
-                        for repo, info in state_data.items():
-                            tag = info.get('last_tag')
-                            updated_at = info.get('updated_at')
-                            if tag:
-                                releases.append(f"- **{repo}** @ `{tag}` (Last Updated: {updated_at})")
-
-                        if releases:
-                            new_releases_str = "\n".join(releases)
-                            recent_commits_str = "Radar sync complete. Please refer to individual repository intel reports. / 雷达同步完成。请参考各个仓库的情报报告。"
-                except Exception as e:
-                    print(f"[Reasoning Error | 推理错误] Failed to read harvester state / 读取收割机状态失败: {e}")
+                releases = self._read_harvester_releases(state_file)
+                if releases:
+                    new_releases_str = "\n".join(releases)
+                    recent_commits_str = "Radar sync complete. Please refer to individual repository intel reports. / 雷达同步完成.请参考各个仓库的情报报告."
 
             # Get stats for dynamic pulse injection
             stats = self.cortex.get_stats()
@@ -368,6 +381,7 @@ class ReasoningEngine:
             print(f"[Reasoning | 推理引擎] Engine successfully rendered Quantitative Dashboard via Templates / 成功通过模板渲染量化仪表盘。")
         except Exception as e:
             print(f"[Reasoning Error | 推理错误] Template enforcement failed / 模板执行失败: {str(e)}")
+            raise
 
     def _generate_structural_intuitions(self):
         """Find nodes that share exact targets (Structural Overlap / Epistemic Depth)"""

--- a/tests/test_harvester.py
+++ b/tests/test_harvester.py
@@ -10,6 +10,7 @@ sys.path.insert(0, str(Path(__file__).parents[1] / "docs" / "brain"))
 from cortex import Cortex
 from harvester import Harvester
 from evolution import Evolver
+from reason import ReasoningEngine
 from scholar import Scholar
 
 
@@ -62,6 +63,28 @@ class HarvesterContracts(unittest.TestCase):
         with patch("evolution.ReasoningEngine", side_effect=RuntimeError("render failed")):
             with self.assertRaisesRegex(RuntimeError, "render failed"):
                 evolver._trigger_render({}, [])
+
+    def test_reason_reads_current_harvester_state_schema(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            state_path = Path(tmp) / ".harvester_state.json"
+            state_path.write_text(
+                json.dumps({
+                    "schema_version": 3,
+                    "baseline": "2026-07-11T13:40:00+08:00",
+                    "repositories": {
+                        "owner/repo": {
+                            "last_tag": "v1",
+                            "last_checked_at": "2026-07-22T00:00:00Z",
+                        }
+                    },
+                }),
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                ReasoningEngine._read_harvester_releases(state_path),
+                ["- **owner/repo** @ `v1` (Last Updated: 2026-07-22T00:00:00Z)"],
+            )
 
     def test_evolver_propagates_mutator_failure(self):
         evolver = Evolver.__new__(Evolver)


### PR DESCRIPTION
## Root cause

The report renderer iterated the entire versioned Harvester state object. The current schema stores scalar metadata such as `schema_version` and `baseline` beside a `repositories` mapping, so calling `.get()` on those top-level values raised `AttributeError: 'str' object has no attribute 'get'`. Both local handling and the outer renderer catch only logged the exception, allowing the lifecycle Action to remain green with stale report content.

## Changes

- Read release metadata exclusively from the current `repositories` mapping.
- Validate the state and repository entry shapes explicitly.
- Use `last_checked_at` when `updated_at` is absent.
- Propagate render failures so the evolution step and Action fail visibly.
- Keep generated Chinese report text on English periods.
- Add one regression test based on the reproduced current state schema.

Only `docs/brain/reason.py` and `tests/test_harvester.py` are changed. No frontend, Pages, archive, generated ledger, SQLite, Horizon Cortex, or other Jules-managed files are included.

## Evidence and validation

Reproduction from the current main state failed with:

```text
AttributeError: 'str' object has no attribute 'get'
```

Validation after the fix:

- `python -B -m unittest discover -s tests -p 'test*.py'`: 18 tests passed.
- Lifecycle syntax contract: 12 Python files compiled.
- Current state read: 15 repository entries parsed without an exception.
- Evolution → report hygiene → post-evolution graph validation passed.
- Final graph: 650 entities, 617 relations, 0 duplicate entities, 0 duplicate relations, 0 dangling relations, 0 invalid records.
- Full GitHub lifecycle run on the validated code: https://github.com/lostlight530/welcome-to-github/actions/runs/29920221812

## Risk and rollback

Malformed Harvester state now intentionally fails the lifecycle instead of silently rendering stale data. Rollback is a single revert of commit `8d79070927e6cd59ba2a2f058175c434e4093ced`.