### PR TITLE
Harden active-memory lifecycle invariants

### DIFF
--- a/.github/workflows/nexus-life-cycle.yml
+++ b/.github/workflows/nexus-life-cycle.yml
@@ -43,10 +43,14 @@ jobs:
         run: python docs/brain/nexus.py project
       - name: Canonicalize Active Ledgers
         run: python -c "import sys; sys.path.insert(0, 'docs/brain'); from document_hygiene import canonicalize_ledger; print(canonicalize_ledger('docs/brain/knowledge'))"
+      - name: Remove Protected Sources from Active Graph
+        run: python -c "import sys; sys.path.insert(0, 'docs/brain'); from document_hygiene import prune_generated_paths; print(prune_generated_paths('docs/brain/knowledge', ('horizon-cortex', 'parallax')))"
       - name: Rebuild Memory
         run: python docs/brain/nexus.py rebuild
       - name: Ingest Self-Codebase
         run: python docs/brain/nexus.py ingest
+      - name: Re-prune Protected Sources
+        run: python -c "import sys; sys.path.insert(0, 'docs/brain'); from document_hygiene import prune_generated_paths; print(prune_generated_paths('docs/brain/knowledge', ('horizon-cortex', 'parallax')))"
       - name: Validate Canonical Graph
         run: python -c "import sys; sys.path.insert(0, 'docs/brain'); from document_hygiene import canonicalize_ledger; repaired=canonicalize_ledger('docs/brain/knowledge'); clean=canonicalize_ledger('docs/brain/knowledge'); print(repaired); print(clean); assert clean['duplicate_entities']==0 and clean['duplicate_relations']==0 and clean['dangling_relations']==0"
       - name: Rebuild Validated Memory
@@ -58,17 +62,57 @@ jobs:
       - name: Render Human-Readable Reports
         run: python docs/brain/report_hygiene.py welcome docs/brain/memories
       - name: Validate Post-Evolution Graph
-        run: python -c "import sys; sys.path.insert(0, 'docs/brain'); from document_hygiene import canonicalize_ledger; post=canonicalize_ledger('docs/brain/knowledge'); print(post); assert post['duplicate_entities']==0 and post['duplicate_relations']==0 and post['dangling_relations']==0"
+        run: python -c "import sys; sys.path.insert(0, 'docs/brain'); from document_hygiene import canonicalize_ledger; repaired=canonicalize_ledger('docs/brain/knowledge'); clean=canonicalize_ledger('docs/brain/knowledge'); print(repaired); print(clean); assert clean['duplicate_entities']==0 and clean['duplicate_relations']==0 and clean['dangling_relations']==0"
+      - name: Rebuild Post-Evolution Memory
+        run: python docs/brain/nexus.py rebuild
       - name: Final Verification
         run: python -m unittest discover -s tests -p 'test*.py'
       - name: Sync World-Line
+        if: github.ref == 'refs/heads/main'
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git pull --rebase --autostash origin "${{ github.ref_name }}"
+          git fetch origin main
+          core_changes="$(git diff --name-only "$GITHUB_SHA..origin/main" | grep -Ev '^docs/brain/(memories|inputs|knowledge)/' || true)"
+          if [ -n "$core_changes" ]; then
+            echo "Core files changed on main while this run was active:"
+            echo "$core_changes"
+            exit 1
+          fi
+          git pull --rebase --autostash origin main
+      - name: Verify Rebased World-Line
+        if: github.ref == 'refs/heads/main'
+        run: |
+          python -c "from pathlib import Path; names=('nexus.py','harvester.py','document_hygiene.py','cortex.py','evolution.py','scholar.py','reason.py','factory.py','report_hygiene.py','report_hygiene_core.py'); files=[Path('docs/brain')/name for name in names] + sorted(Path('tests').glob('*.py')); [compile(path.read_bytes(), str(path), 'exec') for path in files]; print(f'compiled {len(files)} lifecycle Python files')"
+          python -m unittest discover -s tests -p 'test*.py'
+          python -c "import sys; sys.path.insert(0, 'docs/brain'); from document_hygiene import canonicalize_ledger; repaired=canonicalize_ledger('docs/brain/knowledge'); clean=canonicalize_ledger('docs/brain/knowledge'); print(repaired); print(clean); assert clean['duplicate_entities']==0 and clean['duplicate_relations']==0 and clean['dangling_relations']==0"
+          python - <<'PY'
+          import subprocess
+
+          allowed = (
+              "docs/brain/memories/",
+              "docs/brain/inputs/",
+              "docs/brain/knowledge/",
+          )
+          commands = (
+              ("git", "diff", "--name-only"),
+              ("git", "ls-files", "--others", "--exclude-standard"),
+          )
+          changed = {
+              path
+              for command in commands
+              for path in subprocess.check_output(command, text=True).splitlines()
+              if path
+          }
+          unexpected = sorted(path for path in changed if not path.startswith(allowed))
+          if unexpected:
+              raise SystemExit(f"unexpected lifecycle paths: {unexpected}")
+          PY
+          git diff --check
       - name: Commit Cognitive Changes
+        if: github.ref == 'refs/heads/main'
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "lifecycle: verified cognitive update [skip ci]"
-          branch: ${{ github.ref_name }}
+          branch: main
           file_pattern: "docs/brain/memories/** docs/brain/inputs/** docs/brain/knowledge/**"

--- a/docs/brain/document_hygiene.py
+++ b/docs/brain/document_hygiene.py
@@ -263,6 +263,130 @@ def canonicalize_ledger(root: Path, hash_chain: bool = False) -> dict:
         "invalid": invalid,
     }
 
+def prune_generated_paths(
+    root: Path,
+    excluded_roots,
+    hash_chain: bool = False,
+) -> dict:
+    root = Path(root)
+    excluded = {
+        str(value).replace("\\", "/").strip("./").lower()
+        for value in excluded_roots
+        if str(value).strip("./")
+    }
+
+    def is_excluded(value) -> bool:
+        normalized = str(value or "").replace("\\", "/").strip("./").lower()
+        return any(
+            normalized == prefix or normalized.startswith(prefix + "/")
+            for prefix in excluded
+        )
+
+    files = _active_jsonl_files(root) if root.exists() else []
+    entities = {}
+    relations = {}
+    for path in files:
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if not line.strip():
+                continue
+            try:
+                raw = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{path}:{number}: invalid JSONL: {exc}") from exc
+            item = _normalize_record(raw)
+            if item.get("id"):
+                entity_id = str(item["id"])
+                if raw.get("invalid_at"):
+                    entities.pop(entity_id, None)
+                else:
+                    entities[entity_id] = item
+            elif item.get("src") and item.get("relation") and item.get("dst"):
+                key = (str(item["src"]), str(item["relation"]), str(item["dst"]))
+                if raw.get("invalid_at"):
+                    relations.pop(key, None)
+                else:
+                    relations[key] = item
+
+    file_prefixes = {
+        "file_" + prefix.replace("/", "_").replace(".", "_")
+        for prefix in excluded
+    }
+    removed = set()
+    for entity_id, item in entities.items():
+        desc = str(item.get("desc", ""))
+        described_path = (
+            desc.split("Source file at:", 1)[1].strip()
+            if "Source file at:" in desc
+            else ""
+        )
+        if (
+            is_excluded(described_path)
+            or is_excluded(item.get("source_path"))
+            or any(entity_id.lower().startswith(prefix) for prefix in file_prefixes)
+        ):
+            removed.add(entity_id)
+
+    derivation_relations = {"defines", "documents"}
+    while True:
+        added = set()
+        for entity_id in set(entities) - removed:
+            incoming = [
+                (source, relation)
+                for source, relation, target in relations
+                if target == entity_id
+            ]
+            if (
+                incoming
+                and all(source in removed for source, _ in incoming)
+                and any(relation in derivation_relations for _, relation in incoming)
+            ):
+                added.add(entity_id)
+        if not added:
+            break
+        removed.update(added)
+
+    kept_entities = {
+        entity_id: item
+        for entity_id, item in entities.items()
+        if entity_id not in removed
+    }
+    kept_relations = {
+        key: item
+        for key, item in relations.items()
+        if key[0] not in removed and key[2] not in removed
+    }
+    for path in files:
+        path.unlink()
+    for entity_type in sorted(
+        {str(item.get("type", "concept")) for item in kept_entities.values()}
+    ):
+        records = sorted(
+            (
+                item
+                for item in kept_entities.values()
+                if str(item.get("type", "concept")) == entity_type
+            ),
+            key=lambda item: str(item["id"]),
+        )
+        _write_records(
+            root / "entities" / f"{_slug(entity_type) or 'concept'}.jsonl",
+            records,
+            root,
+            hash_chain,
+        )
+    _write_records(
+        root / "relations" / "canonical.jsonl",
+        [kept_relations[key] for key in sorted(kept_relations)],
+        root,
+        hash_chain,
+    )
+    return {
+        "removed_entities": len(entities) - len(kept_entities),
+        "removed_relations": len(relations) - len(kept_relations),
+        "entities": len(kept_entities),
+        "relations": len(kept_relations),
+    }
+
 
 def _snapshot_metadata(path: Path) -> dict | None:
     text = path.read_text(encoding="utf-8")
@@ -330,9 +454,42 @@ def project_current_snapshots(inputs: Path, knowledge: Path, hash_chain: bool = 
         knowledge,
         hash_chain,
     )
+    relation_root = knowledge / "relations"
+    relation_files = (
+        _active_jsonl_files(relation_root) if relation_root.exists() else []
+    )
+    preserved_relations = {}
+    for path in relation_files:
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if not line.strip():
+                continue
+            try:
+                raw = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{path}:{number}: invalid JSONL: {exc}") from exc
+            item = _normalize_record(raw)
+            if not (
+                item.get("src") and item.get("relation") and item.get("dst")
+            ):
+                continue
+            key = (str(item["src"]), str(item["relation"]), str(item["dst"]))
+            scoped = (
+                key[1] == "has_snapshot"
+                and key[0].startswith("external_repo_")
+                and key[2].startswith("external_doc_")
+            )
+            if scoped:
+                continue
+            if raw.get("invalid_at"):
+                preserved_relations.pop(key, None)
+            else:
+                preserved_relations[key] = item
+    for path in relation_files:
+        path.unlink()
+    preserved_relations.update(relations)
     _write_records(
-        knowledge / "relations" / "external_documents.jsonl",
-        [relations[key] for key in sorted(relations)],
+        knowledge / "relations" / "canonical.jsonl",
+        [preserved_relations[key] for key in sorted(preserved_relations)],
         knowledge,
         hash_chain,
     )

--- a/docs/brain/harvester.py
+++ b/docs/brain/harvester.py
@@ -26,12 +26,11 @@ class Harvester:
             self.inputs = project / "data" / "inputs"
             self.profile_path = self.inputs / "source_profiles.json"
         self.state_path = self.inputs / ".harvester_state.json"
-        self.cache = self.inputs / ".raw_cache"
         self.token = os.environ.get("GITHUB_TOKEN", "")
         self.dry = os.environ.get("HARVESTER_DRY_RUN", "0") == "1"
         self.profiles = self._json(self.profile_path, {})
         old = self._json(self.state_path, {})
-        self.state = old if "repositories" in old else {"schema_version": 3, "legacy_state": old, "repositories": {}}
+        self.state = self._validated_state(old)
 
     @staticmethod
     def _json(path, default):
@@ -39,6 +38,45 @@ class Harvester:
             return json.loads(Path(path).read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             return default
+
+    @staticmethod
+    def _validated_state(state):
+        if not isinstance(state, dict):
+            raise ValueError("harvester state must be a mapping")
+        repositories = state.get("repositories")
+        if repositories is None:
+            return {
+                "schema_version": 3,
+                "legacy_state": state,
+                "repositories": {},
+            }
+        if not isinstance(repositories, dict):
+            raise ValueError("harvester state repositories must be a mapping")
+        for repo, repo_state in repositories.items():
+            if not isinstance(repo_state, dict):
+                raise ValueError(f"repository state must be a mapping: {repo}")
+            documents = repo_state.get("documents")
+            if documents is None:
+                repo_state["documents"] = {}
+            elif not isinstance(documents, dict):
+                raise ValueError(f"repository documents must be a mapping: {repo}")
+        return state
+
+    def _blob_text(self, repo, sha):
+        blob = self._api(f"https://api.github.com/repos/{repo}/git/blobs/{sha}")
+        if not isinstance(blob, dict) or blob.get("encoding") != "base64":
+            raise ValueError(f"unsupported blob encoding: {repo}@{sha}")
+        return base64.b64decode(blob["content"]).decode("utf-8", errors="replace")
+
+    @staticmethod
+    def _move_to_archive(source, destination):
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if destination.exists():
+            if source.read_bytes() != destination.read_bytes():
+                raise FileExistsError(f"archive collision: {destination}")
+            source.unlink()
+            return
+        os.replace(source, destination)
 
     def _api(self, url):
         headers = {"Accept": "application/vnd.github+json", "User-Agent": "Nexus-Document-Harvester/3"}
@@ -96,9 +134,8 @@ class Harvester:
         for stale in target.parent.glob(prefix + "*.md"):
             if stale == target:
                 continue
-            archive.mkdir(parents=True, exist_ok=True)
             destination = archive / stale.name
-            os.replace(stale, destination)
+            self._move_to_archive(stale, destination)
             archived.append(destination.relative_to(self.inputs).as_posix())
         return archived
 
@@ -109,57 +146,56 @@ class Harvester:
         if tree.get("truncated"):
             raise ValueError(f"truncated repository tree: {repo}")
         repo_state = self.state["repositories"].setdefault(repo, {"documents": {}})
+        if not isinstance(repo_state, dict) or not isinstance(
+            repo_state.get("documents"), dict
+        ):
+            raise ValueError(f"invalid repository state: {repo}")
         changed = []
+        namespace = repo.lower().replace("/", "_").replace("-", "_")
         items = [item for item in tree.get("tree", []) if item.get("type") == "blob" and self._selected(item["path"], profile.get("documents", []), profile.get("ignore_patterns", []))]
+        selected_paths = {item["path"] for item in items}
         for item in sorted(items, key=lambda value: value["path"]):
             path, sha = item["path"], item["sha"]
             previous = repo_state["documents"].get(path, {})
             if previous.get("sha") == sha:
                 continue
-            blob = self._api(f"https://api.github.com/repos/{repo}/git/blobs/{sha}")
-            if blob.get("encoding") != "base64":
-                raise ValueError(f"unsupported blob encoding: {repo}/{path}")
-            text = base64.b64decode(blob["content"]).decode("utf-8", errors="replace")
+            text = self._blob_text(repo, sha)
             digest = hashlib.sha256(self._normalized(text).encode()).hexdigest()
             if previous.get("content_hash") == digest:
                 repo_state["documents"][path] = {**previous, "sha": sha}
                 continue
-            namespace = repo.lower().replace("/", "_").replace("-", "_")
             entity = f"external_doc_{namespace}_{re.sub(r'[^a-z0-9]+', '_', path.lower()).strip('_' )}"
             target = self.inputs / "current" / profile["layer"] / namespace / (path.replace("/", "__") + f"__{sha[:12]}.md")
-            cache = self.cache / namespace / (path.replace("/", "__") + ".txt")
-            old = cache.read_text(encoding="utf-8") if cache.exists() else ""
+            old = self._blob_text(repo, previous["sha"]) if previous.get("sha") else ""
             diff = "\n".join(difflib.unified_diff(old.splitlines(), text.splitlines(), fromfile="previous", tofile=sha, n=3))
             provenance = {"source_repo": repo, "source_path": path, "source_sha": sha, "retrieved_at": dt.datetime.now(dt.timezone.utc).isoformat(), "confidence": 1.0, "primary_owner": profile["primary_owner"], "entity_id": entity}
             rendered = render_snapshot(provenance, text, diff, profile["layer"])
             validate_owned_punctuation(rendered)
             if not self.dry:
                 target.parent.mkdir(parents=True, exist_ok=True)
-                cache.parent.mkdir(parents=True, exist_ok=True)
                 self._archive_stale(target, path, profile["layer"], namespace)
                 atomic_write(target, rendered)
-                atomic_write(cache, text)
             relative = target.relative_to(self.inputs).as_posix()
             repo_state["documents"][path] = {"sha": sha, "content_hash": digest, "entity_id": entity, "output": relative}
             changed.append(relative)
+        for path in sorted(set(repo_state["documents"]) - selected_paths):
+            previous = repo_state["documents"][path]
+            output = previous.get("output")
+            if output and not self.dry:
+                snapshot = self.inputs / output
+                if snapshot.exists():
+                    destination = (
+                        self.inputs
+                        / "archive"
+                        / dt.datetime.now(dt.timezone.utc).strftime("%Y/%m")
+                        / profile["layer"]
+                        / namespace
+                        / snapshot.name
+                    )
+                    self._move_to_archive(snapshot, destination)
+            del repo_state["documents"][path]
         repo_state["last_checked_at"] = dt.datetime.now(dt.timezone.utc).isoformat()
         return changed
-
-    def _prune_cache(self):
-        expected = set()
-        for repo, repo_state in self.state.get("repositories", {}).items():
-            namespace = repo.lower().replace("/", "_").replace("-", "_")
-            for source_path in repo_state.get("documents", {}):
-                expected.add((self.cache / namespace / (source_path.replace("/", "__") + ".txt")).resolve())
-        removed = 0
-        if self.cache.exists():
-            for path in sorted(self.cache.rglob("*"), reverse=True):
-                if path.is_file() and path.resolve() not in expected:
-                    path.unlink()
-                    removed += 1
-                elif path.is_dir() and not any(path.iterdir()):
-                    path.rmdir()
-        return removed
     def fetch_github_data(self):
         self.validate_profiles()
         changed, failures = [], []

--- a/docs/brain/knowledge/entities/code_class.jsonl
+++ b/docs/brain/knowledge/entities/code_class.jsonl
@@ -9,4 +9,5 @@
 {"desc":"Python Class","id":"file_docs_brain_reason_py__class_ReasoningEngine","name":"ReasoningEngine","type":"code_class"}
 {"desc":"Python Class","id":"file_docs_brain_scholar_py__class_Scholar","name":"Scholar","type":"code_class"}
 {"desc":"Python Class","id":"file_tests_test_harvester_py__class_HarvesterContracts","name":"HarvesterContracts","type":"code_class"}
+{"desc":"Python Class","id":"file_tests_test_harvester_py__class_RecordingCortex","name":"RecordingCortex","type":"code_class"}
 {"desc":"Python Class","id":"file_tests_test_harvester_readability_py__class_ReadabilityContracts","name":"ReadabilityContracts","type":"code_class"}

--- a/docs/brain/knowledge/entities/code_file.jsonl
+++ b/docs/brain/knowledge/entities/code_file.jsonl
@@ -16,6 +16,5 @@
 {"desc":"Source file at: docs/brain/source_profiles.json","id":"file_docs_brain_source_profiles_json","name":"source_profiles.json","type":"code_file"}
 {"desc":"Source file at: docs/brain/test_mcp.py","id":"file_docs_brain_test_mcp_py","name":"test_mcp.py","type":"code_file"}
 {"desc":"Source file at: format.py","id":"file_format_py","name":"format.py","type":"code_file"}
-{"desc":"Source file at: parallax/tools/check.py","id":"file_parallax_tools_check_py","name":"check.py","type":"code_file"}
 {"desc":"Source file at: tests/test_harvester.py","id":"file_tests_test_harvester_py","name":"test_harvester.py","type":"code_file"}
 {"desc":"Source file at: tests/test_harvester_readability.py","id":"file_tests_test_harvester_readability_py","name":"test_harvester_readability.py","type":"code_file"}

--- a/docs/brain/knowledge/entities/code_function.jsonl
+++ b/docs/brain/knowledge/entities/code_function.jsonl
@@ -19,9 +19,11 @@
 {"desc":"Python Function","id":"file_docs_brain_document_hygiene_py__func_atomic_write","name":"atomic_write","type":"code_function"}
 {"desc":"Python Function","id":"file_docs_brain_document_hygiene_py__func_canonicalize_ledger","name":"canonicalize_ledger","type":"code_function"}
 {"desc":"Python Function","id":"file_docs_brain_document_hygiene_py__func_headings","name":"headings","type":"code_function"}
+{"desc":"Python Function","id":"file_docs_brain_document_hygiene_py__func_is_excluded","name":"is_excluded","type":"code_function"}
 {"desc":"Python Function","id":"file_docs_brain_document_hygiene_py__func_ledger_hash","name":"ledger_hash","type":"code_function"}
 {"desc":"Python Function","id":"file_docs_brain_document_hygiene_py__func_maintain_jsonl","name":"maintain_jsonl","type":"code_function"}
 {"desc":"Python Function","id":"file_docs_brain_document_hygiene_py__func_project_current_snapshots","name":"project_current_snapshots","type":"code_function"}
+{"desc":"Python Function","id":"file_docs_brain_document_hygiene_py__func_prune_generated_paths","name":"prune_generated_paths","type":"code_function"}
 {"desc":"Python Function","id":"file_docs_brain_document_hygiene_py__func_render_snapshot","name":"render_snapshot","type":"code_function"}
 {"desc":"Python Function","id":"file_docs_brain_document_hygiene_py__func_validate_owned_punctuation","name":"validate_owned_punctuation","type":"code_function"}
 {"desc":"Python Function","id":"file_docs_brain_document_hygiene_py__func_verify_hash_chain","name":"verify_hash_chain","type":"code_function"}
@@ -43,11 +45,14 @@
 {"desc":"Python Function","id":"file_docs_brain_harvester_py__func___init__","name":"__init__","type":"code_function"}
 {"desc":"Python Function","id":"file_docs_brain_harvester_py__func__api","name":"_api","type":"code_function"}
 {"desc":"Python Function","id":"file_docs_brain_harvester_py__func__archive_stale","name":"_archive_stale","type":"code_function"}
+{"desc":"Python Function","id":"file_docs_brain_harvester_py__func__blob_text","name":"_blob_text","type":"code_function"}
 {"desc":"Python Function","id":"file_docs_brain_harvester_py__func__json","name":"_json","type":"code_function"}
+{"desc":"Python Function","id":"file_docs_brain_harvester_py__func__move_to_archive","name":"_move_to_archive","type":"code_function"}
 {"desc":"Python Function","id":"file_docs_brain_harvester_py__func__normalized","name":"_normalized","type":"code_function"}
 {"desc":"Python Function","id":"file_docs_brain_harvester_py__func__prune_cache","name":"_prune_cache","type":"code_function"}
 {"desc":"Python Function","id":"file_docs_brain_harvester_py__func__selected","name":"_selected","type":"code_function"}
 {"desc":"Python Function","id":"file_docs_brain_harvester_py__func__source","name":"_source","type":"code_function"}
+{"desc":"Python Function","id":"file_docs_brain_harvester_py__func__validated_state","name":"_validated_state","type":"code_function"}
 {"desc":"Python Function","id":"file_docs_brain_harvester_py__func_fetch_github_data","name":"fetch_github_data","type":"code_function"}
 {"desc":"Python Function","id":"file_docs_brain_harvester_py__func_validate_profiles","name":"validate_profiles","type":"code_function"}
 {"desc":"Python Function","id":"file_docs_brain_nexus_mcp_py__func___init__","name":"__init__","type":"code_function"}
@@ -83,14 +88,18 @@
 {"desc":"Use Python's native AST to understand code structure.","id":"file_docs_brain_scholar_py__func__analyze_python_ast","name":"_analyze_python_ast","type":"code_function"}
 {"desc":"Python Function","id":"file_docs_brain_scholar_py__func__digest_file","name":"_digest_file","type":"code_function"}
 {"desc":"Python Function","id":"file_docs_brain_scholar_py__func__extract_props","name":"_extract_props","type":"code_function"}
+{"desc":"Build a platform-independent entity ID from a repository path.","id":"file_docs_brain_scholar_py__func__file_id","name":"_file_id","type":"code_function"}
+{"desc":"Python Function","id":"file_docs_brain_scholar_py__func__is_supported_path","name":"_is_supported_path","type":"code_function"}
 {"desc":"Python Function","id":"file_docs_brain_scholar_py__func__load_config","name":"_load_config","type":"code_function"}
 {"desc":"Phase V: Strip version numbers to ensure pure entity IDs.","id":"file_docs_brain_scholar_py__func__strip_version","name":"_strip_version","type":"code_function"}
 {"desc":"[Omniscience Protocol] Deep scan of the codebase.","id":"file_docs_brain_scholar_py__func_ingest_repository","name":"ingest_repository","type":"code_function"}
 {"desc":"Legacy single file learning (kept for compatibility)","id":"file_docs_brain_scholar_py__func_learn","name":"learn","type":"code_function"}
 {"desc":"Python Function","id":"file_docs_brain_test_mcp_py__func_test_mcp_server","name":"test_mcp_server","type":"code_function"}
-{"desc":"Python Function","id":"file_parallax_tools_check_py__func_main","name":"main","type":"code_function"}
-{"desc":"Python Function","id":"file_parallax_tools_check_py__func_validate","name":"validate","type":"code_function"}
+{"desc":"Python Function","id":"file_tests_test_harvester_py__func___init__","name":"__init__","type":"code_function"}
+{"desc":"Python Function","id":"file_tests_test_harvester_py__func_add_entity","name":"add_entity","type":"code_function"}
+{"desc":"Python Function","id":"file_tests_test_harvester_py__func_connect_entities","name":"connect_entities","type":"code_function"}
 {"desc":"Python Function","id":"file_tests_test_harvester_py__func_test_api_retries_transient_network_failures_with_backoff","name":"test_api_retries_transient_network_failures_with_backoff","type":"code_function"}
+{"desc":"Python Function","id":"file_tests_test_harvester_py__func_test_archive_collision_never_overwrites_different_content","name":"test_archive_collision_never_overwrites_different_content","type":"code_function"}
 {"desc":"Python Function","id":"file_tests_test_harvester_py__func_test_evolver_keeps_input_contract_out_of_monthly_archive","name":"test_evolver_keeps_input_contract_out_of_monthly_archive","type":"code_function"}
 {"desc":"Python Function","id":"file_tests_test_harvester_py__func_test_evolver_propagates_cycle_failure","name":"test_evolver_propagates_cycle_failure","type":"code_function"}
 {"desc":"Python Function","id":"file_tests_test_harvester_py__func_test_evolver_propagates_mutator_failure","name":"test_evolver_propagates_mutator_failure","type":"code_function"}
@@ -99,13 +108,21 @@
 {"desc":"Python Function","id":"file_tests_test_harvester_py__func_test_noise_normalization","name":"test_noise_normalization","type":"code_function"}
 {"desc":"Python Function","id":"file_tests_test_harvester_py__func_test_orphan_suturing_creates_its_target_entity","name":"test_orphan_suturing_creates_its_target_entity","type":"code_function"}
 {"desc":"Python Function","id":"file_tests_test_harvester_py__func_test_orphan_suturing_propagates_write_failure","name":"test_orphan_suturing_propagates_write_failure","type":"code_function"}
+{"desc":"Python Function","id":"file_tests_test_harvester_py__func_test_previous_diff_baseline_comes_from_recorded_git_blob","name":"test_previous_diff_baseline_comes_from_recorded_git_blob","type":"code_function"}
 {"desc":"Python Function","id":"file_tests_test_harvester_py__func_test_profiles_have_unique_welcome_owner","name":"test_profiles_have_unique_welcome_owner","type":"code_function"}
 {"desc":"Python Function","id":"file_tests_test_harvester_py__func_test_reason_reads_current_harvester_state_schema","name":"test_reason_reads_current_harvester_state_schema","type":"code_function"}
+{"desc":"Python Function","id":"file_tests_test_harvester_py__func_test_rebuild_does_not_open_database_before_replacing_it","name":"test_rebuild_does_not_open_database_before_replacing_it","type":"code_function"}
+{"desc":"Python Function","id":"file_tests_test_harvester_py__func_test_removed_source_is_archived_and_removed_from_state","name":"test_removed_source_is_archived_and_removed_from_state","type":"code_function"}
+{"desc":"Python Function","id":"file_tests_test_harvester_py__func_test_scholar_excludes_parallel_systems_and_unsupported_files","name":"test_scholar_excludes_parallel_systems_and_unsupported_files","type":"code_function"}
+{"desc":"Python Function","id":"file_tests_test_harvester_py__func_test_scholar_file_ids_are_platform_independent","name":"test_scholar_file_ids_are_platform_independent","type":"code_function"}
+{"desc":"Python Function","id":"file_tests_test_harvester_py__func_test_scholar_links_only_local_inheritance_targets","name":"test_scholar_links_only_local_inheritance_targets","type":"code_function"}
+{"desc":"Python Function","id":"file_tests_test_harvester_py__func_test_state_rejects_non_mapping_repository_records","name":"test_state_rejects_non_mapping_repository_records","type":"code_function"}
 {"desc":"Python Function","id":"file_tests_test_harvester_py__func_test_structural_array_index_is_not_treated_as_a_version","name":"test_structural_array_index_is_not_treated_as_a_version","type":"code_function"}
 {"desc":"Python Function","id":"file_tests_test_harvester_readability_py__func_test_canonicalization_normalizes_description_alias","name":"test_canonicalization_normalizes_description_alias","type":"code_function"}
 {"desc":"Python Function","id":"file_tests_test_harvester_readability_py__func_test_canonicalization_removes_semantic_duplicates_and_dangling_relations","name":"test_canonicalization_removes_semantic_duplicates_and_dangling_relations","type":"code_function"}
 {"desc":"Python Function","id":"file_tests_test_harvester_readability_py__func_test_current_snapshot_projection_is_stable_and_idempotent","name":"test_current_snapshot_projection_is_stable_and_idempotent","type":"code_function"}
 {"desc":"Python Function","id":"file_tests_test_harvester_readability_py__func_test_jsonl_maintenance_recurses_and_deduplicates","name":"test_jsonl_maintenance_recurses_and_deduplicates","type":"code_function"}
+{"desc":"Python Function","id":"file_tests_test_harvester_readability_py__func_test_pruning_excluded_sources_rebuilds_only_active_ledger","name":"test_pruning_excluded_sources_rebuilds_only_active_ledger","type":"code_function"}
 {"desc":"Python Function","id":"file_tests_test_harvester_readability_py__func_test_snapshot_is_human_readable_and_traceable","name":"test_snapshot_is_human_readable_and_traceable","type":"code_function"}
 {"desc":"Python Function","id":"file_tests_test_harvester_readability_py__func_test_truncated_tree_is_a_hard_failure","name":"test_truncated_tree_is_a_hard_failure","type":"code_function"}
 {"desc":"Python Function","id":"func__api","name":"_api","type":"code_function"}

--- a/docs/brain/knowledge/relations/canonical.jsonl
+++ b/docs/brain/knowledge/relations/canonical.jsonl
@@ -75,9 +75,11 @@
 {"desc":"","dst":"file_docs_brain_document_hygiene_py__func_atomic_write","relation":"defines","src":"file_docs_brain_document_hygiene_py"}
 {"desc":"","dst":"file_docs_brain_document_hygiene_py__func_canonicalize_ledger","relation":"defines","src":"file_docs_brain_document_hygiene_py"}
 {"desc":"","dst":"file_docs_brain_document_hygiene_py__func_headings","relation":"defines","src":"file_docs_brain_document_hygiene_py"}
+{"desc":"","dst":"file_docs_brain_document_hygiene_py__func_is_excluded","relation":"defines","src":"file_docs_brain_document_hygiene_py"}
 {"desc":"","dst":"file_docs_brain_document_hygiene_py__func_ledger_hash","relation":"defines","src":"file_docs_brain_document_hygiene_py"}
 {"desc":"","dst":"file_docs_brain_document_hygiene_py__func_maintain_jsonl","relation":"defines","src":"file_docs_brain_document_hygiene_py"}
 {"desc":"","dst":"file_docs_brain_document_hygiene_py__func_project_current_snapshots","relation":"defines","src":"file_docs_brain_document_hygiene_py"}
+{"desc":"","dst":"file_docs_brain_document_hygiene_py__func_prune_generated_paths","relation":"defines","src":"file_docs_brain_document_hygiene_py"}
 {"desc":"","dst":"file_docs_brain_document_hygiene_py__func_render_snapshot","relation":"defines","src":"file_docs_brain_document_hygiene_py"}
 {"desc":"","dst":"file_docs_brain_document_hygiene_py__func_validate_owned_punctuation","relation":"defines","src":"file_docs_brain_document_hygiene_py"}
 {"desc":"","dst":"file_docs_brain_document_hygiene_py__func_verify_hash_chain","relation":"defines","src":"file_docs_brain_document_hygiene_py"}
@@ -108,11 +110,14 @@
 {"desc":"","dst":"file_docs_brain_harvester_py__func___init__","relation":"defines","src":"file_docs_brain_harvester_py"}
 {"desc":"","dst":"file_docs_brain_harvester_py__func__api","relation":"defines","src":"file_docs_brain_harvester_py"}
 {"desc":"","dst":"file_docs_brain_harvester_py__func__archive_stale","relation":"defines","src":"file_docs_brain_harvester_py"}
+{"desc":"","dst":"file_docs_brain_harvester_py__func__blob_text","relation":"defines","src":"file_docs_brain_harvester_py"}
 {"desc":"","dst":"file_docs_brain_harvester_py__func__json","relation":"defines","src":"file_docs_brain_harvester_py"}
+{"desc":"","dst":"file_docs_brain_harvester_py__func__move_to_archive","relation":"defines","src":"file_docs_brain_harvester_py"}
 {"desc":"","dst":"file_docs_brain_harvester_py__func__normalized","relation":"defines","src":"file_docs_brain_harvester_py"}
 {"desc":"","dst":"file_docs_brain_harvester_py__func__prune_cache","relation":"defines","src":"file_docs_brain_harvester_py"}
 {"desc":"","dst":"file_docs_brain_harvester_py__func__selected","relation":"defines","src":"file_docs_brain_harvester_py"}
 {"desc":"","dst":"file_docs_brain_harvester_py__func__source","relation":"defines","src":"file_docs_brain_harvester_py"}
+{"desc":"","dst":"file_docs_brain_harvester_py__func__validated_state","relation":"defines","src":"file_docs_brain_harvester_py"}
 {"desc":"","dst":"file_docs_brain_harvester_py__func_fetch_github_data","relation":"defines","src":"file_docs_brain_harvester_py"}
 {"desc":"","dst":"file_docs_brain_harvester_py__func_validate_profiles","relation":"defines","src":"file_docs_brain_harvester_py"}
 {"desc":"Auto-sutured ghost node / 自动缝合的幽灵节点","dst":"concept_nexus_system","relation":"is_capability_of","src":"file_docs_brain_mcp_demo_py"}
@@ -159,6 +164,8 @@
 {"desc":"","dst":"file_docs_brain_scholar_py__func__analyze_python_ast","relation":"defines","src":"file_docs_brain_scholar_py"}
 {"desc":"","dst":"file_docs_brain_scholar_py__func__digest_file","relation":"defines","src":"file_docs_brain_scholar_py"}
 {"desc":"","dst":"file_docs_brain_scholar_py__func__extract_props","relation":"defines","src":"file_docs_brain_scholar_py"}
+{"desc":"","dst":"file_docs_brain_scholar_py__func__file_id","relation":"defines","src":"file_docs_brain_scholar_py"}
+{"desc":"","dst":"file_docs_brain_scholar_py__func__is_supported_path","relation":"defines","src":"file_docs_brain_scholar_py"}
 {"desc":"","dst":"file_docs_brain_scholar_py__func__load_config","relation":"defines","src":"file_docs_brain_scholar_py"}
 {"desc":"","dst":"file_docs_brain_scholar_py__func__strip_version","relation":"defines","src":"file_docs_brain_scholar_py"}
 {"desc":"","dst":"file_docs_brain_scholar_py__func_ingest_repository","relation":"defines","src":"file_docs_brain_scholar_py"}
@@ -573,11 +580,14 @@
 {"desc":"","dst":"file_docs_brain_source_profiles_json_prop_sources_9_watch_releases","relation":"defines","src":"file_docs_brain_source_profiles_json"}
 {"desc":"","dst":"file_docs_brain_test_mcp_py__func_test_mcp_server","relation":"defines","src":"file_docs_brain_test_mcp_py"}
 {"desc":"Auto-sutured ghost node / 自动缝合的幽灵节点","dst":"concept_nexus_system","relation":"is_capability_of","src":"file_format_py"}
-{"desc":"","dst":"file_parallax_tools_check_py__func_main","relation":"defines","src":"file_parallax_tools_check_py"}
-{"desc":"","dst":"file_parallax_tools_check_py__func_validate","relation":"defines","src":"file_parallax_tools_check_py"}
 {"desc":"","dst":"class_HarvesterContracts","relation":"defines","src":"file_tests_test_harvester_py"}
 {"desc":"","dst":"file_tests_test_harvester_py__class_HarvesterContracts","relation":"defines","src":"file_tests_test_harvester_py"}
+{"desc":"","dst":"file_tests_test_harvester_py__class_RecordingCortex","relation":"defines","src":"file_tests_test_harvester_py"}
+{"desc":"","dst":"file_tests_test_harvester_py__func___init__","relation":"defines","src":"file_tests_test_harvester_py"}
+{"desc":"","dst":"file_tests_test_harvester_py__func_add_entity","relation":"defines","src":"file_tests_test_harvester_py"}
+{"desc":"","dst":"file_tests_test_harvester_py__func_connect_entities","relation":"defines","src":"file_tests_test_harvester_py"}
 {"desc":"","dst":"file_tests_test_harvester_py__func_test_api_retries_transient_network_failures_with_backoff","relation":"defines","src":"file_tests_test_harvester_py"}
+{"desc":"","dst":"file_tests_test_harvester_py__func_test_archive_collision_never_overwrites_different_content","relation":"defines","src":"file_tests_test_harvester_py"}
 {"desc":"","dst":"file_tests_test_harvester_py__func_test_evolver_keeps_input_contract_out_of_monthly_archive","relation":"defines","src":"file_tests_test_harvester_py"}
 {"desc":"","dst":"file_tests_test_harvester_py__func_test_evolver_propagates_cycle_failure","relation":"defines","src":"file_tests_test_harvester_py"}
 {"desc":"","dst":"file_tests_test_harvester_py__func_test_evolver_propagates_mutator_failure","relation":"defines","src":"file_tests_test_harvester_py"}
@@ -586,8 +596,15 @@
 {"desc":"","dst":"file_tests_test_harvester_py__func_test_noise_normalization","relation":"defines","src":"file_tests_test_harvester_py"}
 {"desc":"","dst":"file_tests_test_harvester_py__func_test_orphan_suturing_creates_its_target_entity","relation":"defines","src":"file_tests_test_harvester_py"}
 {"desc":"","dst":"file_tests_test_harvester_py__func_test_orphan_suturing_propagates_write_failure","relation":"defines","src":"file_tests_test_harvester_py"}
+{"desc":"","dst":"file_tests_test_harvester_py__func_test_previous_diff_baseline_comes_from_recorded_git_blob","relation":"defines","src":"file_tests_test_harvester_py"}
 {"desc":"","dst":"file_tests_test_harvester_py__func_test_profiles_have_unique_welcome_owner","relation":"defines","src":"file_tests_test_harvester_py"}
 {"desc":"","dst":"file_tests_test_harvester_py__func_test_reason_reads_current_harvester_state_schema","relation":"defines","src":"file_tests_test_harvester_py"}
+{"desc":"","dst":"file_tests_test_harvester_py__func_test_rebuild_does_not_open_database_before_replacing_it","relation":"defines","src":"file_tests_test_harvester_py"}
+{"desc":"","dst":"file_tests_test_harvester_py__func_test_removed_source_is_archived_and_removed_from_state","relation":"defines","src":"file_tests_test_harvester_py"}
+{"desc":"","dst":"file_tests_test_harvester_py__func_test_scholar_excludes_parallel_systems_and_unsupported_files","relation":"defines","src":"file_tests_test_harvester_py"}
+{"desc":"","dst":"file_tests_test_harvester_py__func_test_scholar_file_ids_are_platform_independent","relation":"defines","src":"file_tests_test_harvester_py"}
+{"desc":"","dst":"file_tests_test_harvester_py__func_test_scholar_links_only_local_inheritance_targets","relation":"defines","src":"file_tests_test_harvester_py"}
+{"desc":"","dst":"file_tests_test_harvester_py__func_test_state_rejects_non_mapping_repository_records","relation":"defines","src":"file_tests_test_harvester_py"}
 {"desc":"","dst":"file_tests_test_harvester_py__func_test_structural_array_index_is_not_treated_as_a_version","relation":"defines","src":"file_tests_test_harvester_py"}
 {"desc":"","dst":"func_test_evolver_keeps_input_contract_out_of_monthly_archive","relation":"defines","src":"file_tests_test_harvester_py"}
 {"desc":"","dst":"func_test_external_links_are_not_selected","relation":"defines","src":"file_tests_test_harvester_py"}
@@ -599,6 +616,7 @@
 {"desc":"","dst":"file_tests_test_harvester_readability_py__func_test_canonicalization_removes_semantic_duplicates_and_dangling_relations","relation":"defines","src":"file_tests_test_harvester_readability_py"}
 {"desc":"","dst":"file_tests_test_harvester_readability_py__func_test_current_snapshot_projection_is_stable_and_idempotent","relation":"defines","src":"file_tests_test_harvester_readability_py"}
 {"desc":"","dst":"file_tests_test_harvester_readability_py__func_test_jsonl_maintenance_recurses_and_deduplicates","relation":"defines","src":"file_tests_test_harvester_readability_py"}
+{"desc":"","dst":"file_tests_test_harvester_readability_py__func_test_pruning_excluded_sources_rebuilds_only_active_ledger","relation":"defines","src":"file_tests_test_harvester_readability_py"}
 {"desc":"","dst":"file_tests_test_harvester_readability_py__func_test_snapshot_is_human_readable_and_traceable","relation":"defines","src":"file_tests_test_harvester_readability_py"}
 {"desc":"","dst":"file_tests_test_harvester_readability_py__func_test_truncated_tree_is_a_hard_failure","relation":"defines","src":"file_tests_test_harvester_readability_py"}
 {"desc":"","dst":"func_test_jsonl_maintenance_recurses_and_deduplicates","relation":"defines","src":"file_tests_test_harvester_readability_py"}

--- a/docs/brain/nexus.py
+++ b/docs/brain/nexus.py
@@ -22,6 +22,8 @@ BRAIN_ROOT = Path(__file__).parent
 DB_PATH = BRAIN_ROOT / "cortex.db"
 
 def main() -> None:
+    cortex = None
+    factory = None
     try:
         parser = argparse.ArgumentParser(description="NEXUS CORTEX: The Sovereign Intelligence")
         subparsers = parser.add_subparsers(dest='command', help='Available commands')
@@ -62,7 +64,6 @@ def main() -> None:
             sys.exit(1)
 
         cortex = Cortex(DB_PATH)
-        factory = KnowledgeFactory(str(BRAIN_ROOT))
 
         if args.command == 'evolve':
             from evolution import Evolver
@@ -92,6 +93,8 @@ def main() -> None:
                 print(f"  - {insight}")
 
         elif args.command == 'rebuild':
+            cortex.conn.close()
+            cortex = None
             if DB_PATH.exists():
                 os.remove(DB_PATH)
             cortex = Cortex(DB_PATH)
@@ -126,16 +129,20 @@ def main() -> None:
             print("Database rebuilt from schemas and JSONL fragments. / 数据库已从 Schema 和 JSONL 碎片重建。")
 
         elif args.command == 'clean':
+            cortex.conn.close()
+            cortex = None
             # Safe cleanup, protect `.harvester_state.json`
             if DB_PATH.exists(): os.remove(DB_PATH)
             if DB_PATH.with_suffix('.db-journal').exists(): os.remove(DB_PATH.with_suffix('.db-journal'))
             print("Temporary caches cleared. / 临时缓存已清理。")
 
         elif args.command == 'add':
+            factory = KnowledgeFactory(str(BRAIN_ROOT))
             data = {"id": args.id, "type": args.type, "name": args.name, "desc": args.desc, "updated_at": datetime.datetime.now().isoformat(), "tags": []}
             factory.add_entity(args.category, data)
 
         elif args.command == 'connect':
+            factory = KnowledgeFactory(str(BRAIN_ROOT))
             data = {"src": args.src, "rel": args.rel, "dst": args.dst, "context": args.desc, "created_at": datetime.datetime.now().isoformat()}
             factory.add_relation(data)
 
@@ -155,6 +162,11 @@ def main() -> None:
         traceback.print_exc()
         print(f"[Nexus Error | Nexus 错误] Execution failed / 执行失败: {e}")
         sys.exit(1)
+    finally:
+        if cortex is not None:
+            cortex.conn.close()
+        if factory is not None:
+            factory.cortex.conn.close()
 
 if __name__ == "__main__":
     main()

--- a/docs/brain/scholar.py
+++ b/docs/brain/scholar.py
@@ -13,6 +13,22 @@ except ImportError:
     pass
 
 class Scholar:
+    PROTECTED_ROOTS = ("horizon-cortex", "parallax")
+    SUPPORTED_SUFFIXES = {
+        ".py", ".js", ".jsx", ".ts", ".tsx",
+        ".cpp", ".cc", ".h", ".hpp", ".c",
+        ".json", ".yaml", ".yml",
+    }
+
+    @classmethod
+    def _is_supported_path(cls, path):
+        normalized = Path(path).as_posix().strip("./").lower()
+        protected = any(
+            normalized == root or normalized.startswith(root + "/")
+            for root in cls.PROTECTED_ROOTS
+        )
+        return not protected and Path(normalized).suffix in cls.SUPPORTED_SUFFIXES
+
     def __init__(self, brain_path):
         self.brain_path = Path(brain_path)
         self.memories_path = self.brain_path / "memories"
@@ -29,7 +45,7 @@ class Scholar:
         self.ignore_dirs = {
             '.git', '__pycache__', 'node_modules', 'dist', 'build', '.github',
             'docs/brain/knowledge', 'docs/brain/inputs', 'docs/brain/memories', '.raw_cache',
-            'docs/archaeology', 'docs/brain/inputs/archive'
+            'docs/archaeology', 'docs/brain/inputs/archive', 'horizon-cortex', 'parallax'
         }
         self.ignore_files = {
             '.DS_Store', 'cortex.db', 'cortex.db-journal', '.gitignore',
@@ -72,6 +88,8 @@ class Scholar:
                 if any(fnmatch.fnmatch(file, pat) for pat in self.ignore_files) or file.endswith(('.pyc', '.db', '.md', '.jsonl')): continue
 
                 filepath = Path(dirpath) / file
+                if not self._is_supported_path(filepath.relative_to(root)):
+                    continue
                 try:
                     self._digest_file(root, filepath)
                     count += 1
@@ -80,9 +98,16 @@ class Scholar:
 
         print(f"✅ Ingestion Complete. {count} files mapped into Cortex. / 提取完成。共映射 {count} 个文件至皮质层。")
 
+    def _file_id(self, rel_path):
+        """Build a platform-independent entity ID from a repository path."""
+        normalized = rel_path.as_posix()
+        return self._strip_version(
+            "file_" + normalized.replace("/", "_").replace(".", "_")
+        )
+
     def _digest_file(self, root, filepath):
         rel_path = filepath.relative_to(root)
-        file_id = self._strip_version(f"file_" + str(rel_path).replace("/", "_").replace(".", "_"))
+        file_id = self._file_id(rel_path)
 
         # 1. Register File Node
         if self.cortex:
@@ -90,7 +115,7 @@ class Scholar:
                 id=file_id,
                 type_slug="code_file",
                 name=filepath.name,
-                desc=f"Source file at: {rel_path}",
+                desc=f"Source file at: {rel_path.as_posix()}",
                 save_to_disk=True
             )
 
@@ -236,6 +261,11 @@ class Scholar:
                 content = f.read()
             tree = ast.parse(content)
 
+            local_classes = {
+                self._strip_version(node.name)
+                for node in ast.walk(tree)
+                if isinstance(node, ast.ClassDef)
+            }
             for node in ast.walk(tree):
                 # Classes
                 if isinstance(node, ast.ClassDef):
@@ -246,9 +276,15 @@ class Scholar:
                     self.cortex.connect_entities(file_id, "defines", class_id, save_to_disk=True)
                     # Inheritance
                     for base in node.bases:
-                        if isinstance(base, ast.Name):
+                        if (
+                            isinstance(base, ast.Name)
+                            and self._strip_version(base.id) in local_classes
+                        ):
                             base_name = self._strip_version(base.id)
-                            self.cortex.connect_entities(class_id, "inherits_from", f"class_{base_name}", save_to_disk=True)
+                            target = self._strip_version(
+                                f"{file_id}__class_{base_name}"
+                            )
+                            self.cortex.connect_entities(class_id, "inherits_from", target, save_to_disk=True)
 
                 # Functions
                 elif isinstance(node, ast.FunctionDef):

--- a/tests/test_harvester.py
+++ b/tests/test_harvester.py
@@ -1,9 +1,10 @@
+import base64
 import json
 import sys
 import tempfile
 import unittest
 import urllib.error
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from unittest.mock import Mock, call, patch
 
 sys.path.insert(0, str(Path(__file__).parents[1] / "docs" / "brain"))
@@ -12,9 +13,115 @@ from harvester import Harvester
 from evolution import Evolver
 from reason import ReasoningEngine
 from scholar import Scholar
+import nexus as nexus_module
 
 
 class HarvesterContracts(unittest.TestCase):
+    def test_state_rejects_non_mapping_repository_records(self):
+        with self.assertRaisesRegex(ValueError, "repositories"):
+            Harvester._validated_state({"repositories": "invalid"})
+
+    def test_previous_diff_baseline_comes_from_recorded_git_blob(self):
+        harvester = Harvester.__new__(Harvester)
+        harvester._api = Mock(
+            return_value={
+                "encoding": "base64",
+                "content": base64.b64encode(b"previous body").decode("ascii"),
+            }
+        )
+
+        self.assertEqual(
+            harvester._blob_text("owner/repo", "old-sha"),
+            "previous body",
+        )
+        harvester._api.assert_called_once_with(
+            "https://api.github.com/repos/owner/repo/git/blobs/old-sha"
+        )
+
+    def test_removed_source_is_archived_and_removed_from_state(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            harvester = Harvester.__new__(Harvester)
+            harvester.inputs = Path(tmp)
+            current = harvester.inputs / "current" / "test" / "owner_repo"
+            current.mkdir(parents=True)
+            snapshot = current / "README.md__old.md"
+            snapshot.write_text("sealed snapshot", encoding="utf-8")
+            harvester.state = {
+                "repositories": {
+                    "owner/repo": {
+                        "documents": {
+                            "README.md": {
+                                "sha": "old",
+                                "output": snapshot.relative_to(harvester.inputs).as_posix(),
+                            }
+                        }
+                    }
+                }
+            }
+            harvester._api = Mock(
+                side_effect=[
+                    {"default_branch": "main"},
+                    {"tree": [], "truncated": False},
+                ]
+            )
+            harvester.dry = False
+
+            changed = harvester._source(
+                {
+                    "repo": "owner/repo",
+                    "documents": ["README.md"],
+                    "ignore_patterns": [],
+                    "layer": "test",
+                    "primary_owner": "welcome",
+                }
+            )
+
+            self.assertEqual(changed, [])
+            self.assertFalse(snapshot.exists())
+            self.assertEqual(
+                list((harvester.inputs / "archive").rglob(snapshot.name))[0].read_text(
+                    encoding="utf-8"
+                ),
+                "sealed snapshot",
+            )
+            self.assertNotIn(
+                "README.md",
+                harvester.state["repositories"]["owner/repo"]["documents"],
+            )
+
+    def test_archive_collision_never_overwrites_different_content(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            harvester = Harvester.__new__(Harvester)
+            harvester.inputs = Path(tmp)
+            current = harvester.inputs / "current" / "test" / "owner_repo"
+            current.mkdir(parents=True)
+            stale = current / "README.md__same.md"
+            stale.write_text("current", encoding="utf-8")
+            archive = (
+                harvester.inputs
+                / "archive"
+                / "2026"
+                / "07"
+                / "test"
+                / "owner_repo"
+                / stale.name
+            )
+            archive.parent.mkdir(parents=True)
+            archive.write_text("sealed", encoding="utf-8")
+
+            with patch("harvester.dt.datetime") as clock:
+                clock.now.return_value.strftime.return_value = "2026/07"
+                with self.assertRaisesRegex(FileExistsError, "archive collision"):
+                    harvester._archive_stale(
+                        current / "README.md__new.md",
+                        "README.md",
+                        "test",
+                        "owner_repo",
+                    )
+
+            self.assertEqual(stale.read_text(encoding="utf-8"), "current")
+            self.assertEqual(archive.read_text(encoding="utf-8"), "sealed")
+
     def test_profiles_have_unique_welcome_owner(self):
         h = Harvester(Path(__file__).parents[1] / "docs" / "brain")
         self.assertTrue(h.validate_profiles())
@@ -152,6 +259,82 @@ class HarvesterContracts(unittest.TestCase):
         with patch.object(cortex, "connect_entities", side_effect=RuntimeError("write failed")):
             with self.assertRaisesRegex(RuntimeError, "write failed"):
                 cortex.suture_orphans()
+
+    def test_scholar_file_ids_are_platform_independent(self):
+        scholar = Scholar.__new__(Scholar)
+        self.assertEqual(
+            scholar._file_id(PureWindowsPath("docs/brain/reason.py")),
+            "file_docs_brain_reason_py",
+        )
+
+    def test_scholar_excludes_parallel_systems_and_unsupported_files(self):
+        self.assertFalse(
+            Scholar._is_supported_path(Path("horizon-cortex/owned.py"))
+        )
+        self.assertFalse(Scholar._is_supported_path(Path("parallax/owned.py")))
+        self.assertFalse(Scholar._is_supported_path(Path("index.html")))
+        self.assertTrue(Scholar._is_supported_path(Path("docs/brain/reason.py")))
+
+    def test_scholar_links_only_local_inheritance_targets(self):
+        class RecordingCortex:
+            def __init__(self):
+                self.entities = []
+                self.relations = []
+
+            def add_entity(
+                self,
+                entity_id,
+                type_slug,
+                name,
+                desc,
+                save_to_disk=True,
+            ):
+                self.entities.append(entity_id)
+
+            def connect_entities(
+                self,
+                source,
+                relation,
+                target,
+                desc="",
+                save_to_disk=True,
+            ):
+                self.relations.append((source, relation, target))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "inheritance.py"
+            source.write_text(
+                "class Base:\n    pass\n\n"
+                "class Child(Base):\n    pass\n\n"
+                "class External(http.server.BaseHTTPRequestHandler):\n    pass\n",
+                encoding="utf-8",
+            )
+            scholar = Scholar.__new__(Scholar)
+            scholar.cortex = RecordingCortex()
+            scholar._analyze_python_ast(source, "file_inheritance_py")
+
+            self.assertIn(
+                (
+                    "file_inheritance_py__class_Child",
+                    "inherits_from",
+                    "file_inheritance_py__class_Base",
+                ),
+                scholar.cortex.relations,
+            )
+            self.assertFalse(
+                any(target.startswith("class_") for _, _, target in scholar.cortex.relations)
+            )
+    def test_rebuild_does_not_open_database_before_replacing_it(self):
+        cortex = Mock()
+        cortex.conn = Mock()
+        with patch.object(sys, "argv", ["nexus.py", "rebuild"]):
+            with patch.object(nexus_module, "Cortex", return_value=cortex) as factory:
+                with patch.object(nexus_module.os, "remove"):
+                    nexus_module.main()
+
+        self.assertEqual(factory.call_count, 2)
+        self.assertEqual(cortex.conn.close.call_count, 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_harvester_readability.py
+++ b/tests/test_harvester_readability.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(Path(__file__).parents[1] / "docs" / "brain"))
 from document_hygiene import (
     canonicalize_ledger,
     maintain_jsonl,
+    prune_generated_paths,
     project_current_snapshots,
     render_snapshot,
     validate_owned_punctuation,
@@ -58,6 +59,11 @@ class ReadabilityContracts(unittest.TestCase):
             self.assertEqual(first, {"documents": 1, "repositories": 1, "relations": 1})
             self.assertEqual(second, first)
             self.assertEqual(after, before)
+            canonicalize_ledger(knowledge)
+            project_current_snapshots(inputs, knowledge)
+            clean = canonicalize_ledger(knowledge)
+            self.assertEqual(clean["duplicate_relations"], 0)
+
             document = json.loads((knowledge / "entities" / "external_document.jsonl").read_text(encoding="utf-8"))
             self.assertEqual(document["id"], "external_doc_owner_repo_readme_md")
 
@@ -121,6 +127,67 @@ class ReadabilityContracts(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "truncated"):
             harvester._source({"repo": "owner/repo", "documents": [], "ignore_patterns": [], "layer": "test", "primary_owner": "welcome"})
 
+
+    def test_pruning_excluded_sources_rebuilds_only_active_ledger(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            entities = root / "entities"
+            relations = root / "relations"
+            archive = root / "archive" / "sealed.jsonl"
+            entities.mkdir()
+            relations.mkdir()
+            archive.parent.mkdir()
+            archive.write_bytes(b'{"id":"sealed"}\n')
+            sealed = archive.read_bytes()
+            records = [
+                {
+                    "id": "file_protected_tool_py",
+                    "type": "code_file",
+                    "name": "tool.py",
+                    "desc": "Source file at: protected/tool.py",
+                },
+                {
+                    "id": "file_protected_tool_py__func_run",
+                    "type": "code_function",
+                    "name": "run",
+                    "desc": "Python Function",
+                },
+                {"id": "safe", "type": "concept", "name": "Safe", "desc": ""},
+                {"id": "shared", "type": "concept", "name": "Shared", "desc": ""},
+            ]
+            (entities / "items.jsonl").write_text(
+                "".join(json.dumps(item) + "\n" for item in records),
+                encoding="utf-8",
+            )
+            relation_records = [
+                {
+                    "src": "file_protected_tool_py",
+                    "relation": "defines",
+                    "dst": "file_protected_tool_py__func_run",
+                },
+                {
+                    "src": "file_protected_tool_py",
+                    "relation": "links",
+                    "dst": "shared",
+                },
+                {"src": "safe", "relation": "links", "dst": "shared"},
+            ]
+            (relations / "items.jsonl").write_text(
+                "".join(json.dumps(item) + "\n" for item in relation_records),
+                encoding="utf-8",
+            )
+
+            result = prune_generated_paths(root, ("protected",))
+            active_ids = {
+                json.loads(line)["id"]
+                for path in (root / "entities").glob("*.jsonl")
+                for line in path.read_text(encoding="utf-8").splitlines()
+            }
+
+            self.assertEqual(result["removed_entities"], 2)
+            self.assertEqual(result["removed_relations"], 2)
+            self.assertEqual(active_ids, {"safe", "shared"})
+            self.assertEqual(archive.read_bytes(), sealed)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Root cause
- Diffing depended on transient raw cache files, so a missing cache could report the full source as new.
- Repository state shape, deleted sources, and archive SHA collisions were not validated deterministically.
- Active graph projection could retain duplicate snapshot relations and protected parallel-system paths.
- Windows path separators produced platform-dependent code entity IDs, and SQLite rebuild opened the target twice.
- Workflow evolution/rebase ordering could hide failures or validate before the final write.

## Scope
- Harden Harvester state, Git-blob baselines, deletion handling, and collision-safe archival.
- Canonicalize and prune only active JSONL; sealed archives are untouched.
- Restrict Scholar to supported backend sources and stable POSIX entity IDs.
- Make rebuild close old database handles before replacement.
- Add post-ingest/post-evolution validation, autostash-safe rebase, concurrent-run protection, and main-only writeback.
- Rebuild the active ledger from the corrected contracts.

## Validation
- 12 lifecycle Python files compiled.
- 27 unittest cases passed.
- Workflow YAML parsed successfully.
- Active graph: 669 entities, 637 relations, 0 duplicates, 0 dangling relations.
- SQLite rebuild succeeded after the final ledger write.
- No protected-directory, frontend, archive, cache, or Chinese-full-stop additions.

## Risk and rollback
Risk is limited to backend lifecycle automation and generated active ledgers. Revert this single commit to restore the prior behavior; sealed archive bytes were not changed. No deployment or merge is performed by this PR.