### PR TITLE
Fix post-merge lifecycle path handling

### DIFF
--- a/.github/workflows/nexus-life-cycle.yml
+++ b/.github/workflows/nexus-life-cycle.yml
@@ -73,7 +73,7 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git fetch origin main
-          core_changes="$(git diff --name-only "$GITHUB_SHA..origin/main" | grep -Ev '^docs/brain/(memories|inputs|knowledge)/' || true)"
+          core_changes="$(git diff --name-only "$GITHUB_SHA..origin/main" | grep -Ev '^(docs/brain/(memories|inputs|knowledge)/|horizon-cortex/|parallax/|src/|index\.html$)' || true)"
           if [ -n "$core_changes" ]; then
             echo "Core files changed on main while this run was active:"
             echo "$core_changes"

--- a/docs/brain/nexus.py
+++ b/docs/brain/nexus.py
@@ -18,7 +18,11 @@ try:
 except ImportError:
     pass
 
-BRAIN_ROOT = Path(__file__).parent
+def _brain_root(module_file):
+    return Path(module_file).resolve().parent
+
+
+BRAIN_ROOT = _brain_root(__file__)
 DB_PATH = BRAIN_ROOT / "cortex.db"
 
 def main() -> None:

--- a/tests/test_harvester.py
+++ b/tests/test_harvester.py
@@ -324,6 +324,12 @@ class HarvesterContracts(unittest.TestCase):
             self.assertFalse(
                 any(target.startswith("class_") for _, _, target in scholar.cortex.relations)
             )
+    def test_nexus_resolves_relative_module_paths(self):
+        brain_root = nexus_module._brain_root("docs/brain/nexus.py")
+
+        self.assertTrue(brain_root.is_absolute())
+        self.assertEqual(brain_root, (Path.cwd() / "docs" / "brain").resolve())
+
     def test_rebuild_does_not_open_database_before_replacing_it(self):
         cortex = Mock()
         cortex.conn = Mock()


### PR DESCRIPTION
## Root cause
The main-only lifecycle verification could resolve `docs/brain` from a relative module path after a working-directory change, producing nested `docs/brain/docs/brain` outputs. The same sync guard also treated protected Jules/Codex and frontend-only main updates as backend-core conflicts.

## Scope
- Resolve the brain root from the canonical absolute module path.
- Add the minimal regression test for relative module paths.
- Exclude generated active-memory, protected-system, and frontend-only paths from the backend-core sync conflict set.

## Validation
- 12 lifecycle Python files compiled.
- 28 existing/regression unittest cases passed.
- Changed-working-directory subprocess confirmed canonical `BRAIN_ROOT`, database, and harvester input paths.
- Ubuntu-compatible grep simulation and workflow YAML parsing passed.
- Final diff audit found no archive, protected-system, frontend, cache, database, or ledger changes.

## Risk and rollback
The change is limited to path canonicalization, one regression test, and the sync path filter. Revert this commit to roll back.