### PR TITLE
Fix MCP sandbox root contract

### DIFF
--- a/.github/workflows/nexus-life-cycle.yml
+++ b/.github/workflows/nexus-life-cycle.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: '3.10'
       - name: Validate Runtime Contracts
         run: |
-          python -c "from pathlib import Path; names=('nexus.py','harvester.py','document_hygiene.py','cortex.py','evolution.py','scholar.py','reason.py','factory.py','report_hygiene.py','report_hygiene_core.py'); files=[Path('docs/brain')/name for name in names] + sorted(Path('tests').glob('*.py')); [compile(path.read_bytes(), str(path), 'exec') for path in files]; print(f'compiled {len(files)} lifecycle Python files')"
+          python -c "from pathlib import Path; names=('nexus.py','nexus_mcp.py','test_mcp.py','harvester.py','document_hygiene.py','cortex.py','evolution.py','scholar.py','reason.py','factory.py','report_hygiene.py','report_hygiene_core.py'); files=[Path('docs/brain')/name for name in names] + sorted(Path('tests').glob('*.py')); [compile(path.read_bytes(), str(path), 'exec') for path in files]; print(f'compiled {len(files)} lifecycle Python files')"
           python -m unittest discover -s tests -p 'test*.py'
       - name: Validate Existing Ledgers
         run: python -c "import sys; sys.path.insert(0, 'docs/brain'); from document_hygiene import maintain_jsonl; print(maintain_jsonl('docs/brain/knowledge'))"
@@ -67,6 +67,31 @@ jobs:
         run: python docs/brain/nexus.py rebuild
       - name: Final Verification
         run: python -m unittest discover -s tests -p 'test*.py'
+      - name: Verify Lifecycle Write Boundary
+        run: |
+          python - <<'PY'
+          import subprocess
+
+          allowed = (
+              "docs/brain/memories/",
+              "docs/brain/inputs/",
+              "docs/brain/knowledge/",
+          )
+          commands = (
+              ("git", "diff", "--name-only"),
+              ("git", "ls-files", "--others", "--exclude-standard"),
+          )
+          changed = {
+              path
+              for command in commands
+              for path in subprocess.check_output(command, text=True).splitlines()
+              if path
+          }
+          unexpected = sorted(path for path in changed if not path.startswith(allowed))
+          if unexpected:
+              raise SystemExit(f"unexpected lifecycle paths: {unexpected}")
+          PY
+          git diff --check
       - name: Sync World-Line
         if: github.ref == 'refs/heads/main'
         run: |
@@ -83,7 +108,7 @@ jobs:
       - name: Verify Rebased World-Line
         if: github.ref == 'refs/heads/main'
         run: |
-          python -c "from pathlib import Path; names=('nexus.py','harvester.py','document_hygiene.py','cortex.py','evolution.py','scholar.py','reason.py','factory.py','report_hygiene.py','report_hygiene_core.py'); files=[Path('docs/brain')/name for name in names] + sorted(Path('tests').glob('*.py')); [compile(path.read_bytes(), str(path), 'exec') for path in files]; print(f'compiled {len(files)} lifecycle Python files')"
+          python -c "from pathlib import Path; names=('nexus.py','nexus_mcp.py','test_mcp.py','harvester.py','document_hygiene.py','cortex.py','evolution.py','scholar.py','reason.py','factory.py','report_hygiene.py','report_hygiene_core.py'); files=[Path('docs/brain')/name for name in names] + sorted(Path('tests').glob('*.py')); [compile(path.read_bytes(), str(path), 'exec') for path in files]; print(f'compiled {len(files)} lifecycle Python files')"
           python -m unittest discover -s tests -p 'test*.py'
           python -c "import sys; sys.path.insert(0, 'docs/brain'); from document_hygiene import canonicalize_ledger; repaired=canonicalize_ledger('docs/brain/knowledge'); clean=canonicalize_ledger('docs/brain/knowledge'); print(repaired); print(clean); assert clean['duplicate_entities']==0 and clean['duplicate_relations']==0 and clean['dangling_relations']==0"
           python - <<'PY'

--- a/docs/brain/test_mcp.py
+++ b/docs/brain/test_mcp.py
@@ -4,12 +4,13 @@ import sys
 import os
 
 # Ensure we test the exact MCP server
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+BRAIN_ROOT = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(BRAIN_ROOT)
 from nexus_mcp import MCPServer
 
 def test_mcp_server():
     print("[Test] Initializing MCP Server test...")
-    server = MCPServer("docs/brain")
+    server = MCPServer(BRAIN_ROOT)
 
     # 1. Test Initialization
     print("[Test] Testing 'initialize'...")


### PR DESCRIPTION
## Root cause

The evolution subprocess runs `test_mcp.py` with `cwd=docs/brain`, but that script passed the relative string `docs/brain` to `MCPServer`. SQLite and the Harvester therefore wrote beneath `docs/brain/docs/brain`, causing the merged main lifecycle to fail its final write-boundary verification.

## Changes

- Derive the MCP sandbox root from `test_mcp.py`'s absolute module location.
- Compile the MCP runtime and sandbox script in both workflow validation phases.
- Run the lifecycle write-boundary check on branch pushes before the main-only sync, so this failure is detected before merge.

## Validation

- Compiled 14 lifecycle Python files.
- Ran all 28 unit tests successfully.
- Ran `test_mcp.py` from an isolated directory that reproduces the real `cwd=docs/brain` contract; it created only `cortex.db` and `inputs/.harvester_state.json` at the canonical root and did not create a nested `docs/brain` directory.
- `git diff --check` passed.
- Diff contains only the workflow and MCP sandbox script; no archive, protected system, frontend, ledger, database, cache, or generated memory files.

## Risk and rollback

The change is limited to sandbox path construction and pre-merge workflow verification. Revert commit `165820f` to roll back.