### PR TITLE
feat: Add H2 Daily Horizon Orient for 2026-07-24

### DIFF
--- a/horizon-cortex/2026-07-24-H2-horizon-orient.md
+++ b/horizon-cortex/2026-07-24-H2-horizon-orient.md
@@ -1,0 +1,34 @@
+CORTEX_RUN_HEADER
+
+Cortex: horizon-cortex
+Host Repository: welcome-to-github
+Task ID: H2
+Cadence: Daily
+Loop Stage: Orient
+Run Date: 2026-07-24
+Agent: Jules
+Knowledge Source: H1 input + External Web + horizon-cortex local files
+Repository Inspection: NO
+GitHub Actions Inspection: NO
+Write Scope: horizon-cortex only
+Boundary Violation: NO
+
+INPUT_RECORD
+INPUT_MISSING
+
+SIGNAL_CLASSIFICATION
+INPUT_MISSING
+
+ORIENTATION_NOTES
+INPUT_MISSING
+
+NO_DECISION_SECTION
+INPUT_MISSING
+
+NEXT_HANDOFF
+INPUT_MISSING
+
+BOUNDARY_CHECK
+确认没有读取宿主仓库机制
+确认没有读取 GitHub Actions
+确认没有写入 horizon-cortex 之外的文件


### PR DESCRIPTION
Creates the daily H2 Orient file for 2026-07-24 in the horizon-cortex directory. Due to the missing H1 input file, all dependent fields are safely populated with INPUT_MISSING, avoiding hallucinated data, and strict operational boundaries are confirmed.

---
*PR created automatically by Jules for task [8697355763252295997](https://jules.google.com/task/8697355763252295997) started by @lostlight530*