### PR TITLE
Prevent Chinese full stops in generated lifecycle reports

### DIFF
--- a/docs/brain/reason.py
+++ b/docs/brain/reason.py
@@ -130,7 +130,7 @@ class ReasoningEngine:
         edges_raw = self._query("SELECT source, target FROM relations WHERE invalid_at IS NULL")
 
         if not nodes_raw or not edges_raw:
-            return "Pending inference. / 等待推演。"
+            return "Pending inference. / 等待推演."
 
         nodes = [row[0] for row in nodes_raw]
         node_names = {row[0]: row[1] for row in nodes_raw}
@@ -139,7 +139,7 @@ class ReasoningEngine:
         ranks = self._calculate_pagerank(nodes, edges)
 
         if not ranks:
-            return "Pending inference. / 等待推演。"
+            return "Pending inference. / 等待推演."
 
         sorted_hubs = sorted(ranks.items(), key=lambda x: x[1], reverse=True)[:limit]
         hub_lines = []
@@ -208,7 +208,7 @@ class ReasoningEngine:
                 relation_growth = 0
 
             # Mission focus
-            mission_focus = "Pending inference. / 等待推演。"
+            mission_focus = "Pending inference. / 等待推演."
             try:
                 mission_path = os.path.join(memories_dir, "MISSION_ACTIVE.md")
                 if os.path.exists(mission_path):
@@ -319,7 +319,7 @@ class ReasoningEngine:
             ledger_path = os.path.join(memories_dir, "QUANTITATIVE_LEDGER.md")
             if not os.path.exists(ledger_path):
                 with open(ledger_path, 'w', encoding='utf-8') as f:
-                    f.write("# 🧮 NEXUS CORTEX 演化账本 (Quantitative Ledger)\n> 严禁覆写，仅限追加记录系统的物理心跳与演进状态。(Append-Only Ledger for System Pulse)\n\n")
+                    f.write("# 🧮 NEXUS CORTEX 演化账本 (Quantitative Ledger)\n> 严禁覆写，仅限追加记录系统的物理心跳与演进状态.(Append-Only Ledger for System Pulse)\n\n")
 
             with open(ledger_path, 'a', encoding='utf-8') as f:
                 f.write(dash_content_ledger)
@@ -333,12 +333,12 @@ class ReasoningEngine:
 
             # Calculate PageRank Target Hub
             pagerank_hub = self._generate_pagerank_bounty()
-            pagerank_str = f"**Cognitive Hub (PageRank)**: `{pagerank_hub}`" if pagerank_hub else "Cognitive Hub: Pending inference. / 等待推演。"
+            pagerank_str = f"**Cognitive Hub (PageRank)**: `{pagerank_hub}`" if pagerank_hub else "Cognitive Hub: Pending inference. / 等待推演."
 
             # Read Harvester State to dynamically render New Releases and Commits
             state_file = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'brain', 'inputs', '.harvester_state.json')
-            new_releases_str = "Awaiting native Harvester ingestion cycle. / 等待原生收割机吞噬周期。"
-            recent_commits_str = "Awaiting repository sync. / 等待代码库同步。"
+            new_releases_str = "Awaiting native Harvester ingestion cycle. / 等待原生收割机吞噬周期."
+            recent_commits_str = "Awaiting repository sync. / 等待代码库同步."
 
             if os.path.exists(state_file):
                 releases = self._read_harvester_releases(state_file)
@@ -378,7 +378,7 @@ class ReasoningEngine:
             with open(os.path.join(memories_dir, "MISSION_ACTIVE.md"), 'w', encoding='utf-8') as f:
                 f.write(mission_content)
 
-            print(f"[Reasoning | 推理引擎] Engine successfully rendered Quantitative Dashboard via Templates / 成功通过模板渲染量化仪表盘。")
+            print(f"[Reasoning | 推理引擎] Engine successfully rendered Quantitative Dashboard via Templates / 成功通过模板渲染量化仪表盘.")
         except Exception as e:
             print(f"[Reasoning Error | 推理错误] Template enforcement failed / 模板执行失败: {str(e)}")
             raise

--- a/docs/brain/report_hygiene.py
+++ b/docs/brain/report_hygiene.py
@@ -6,8 +6,7 @@ import report_hygiene_core as core
 
 
 def validate_owned_report(text):
-    owned = text.split("<details>", 1)[0]
-    if "。" in owned:
+    if "。" in text:
         raise ValueError("generated report contains a Chinese full stop")
 
 

--- a/tests/test_report_hygiene_full_output.py
+++ b/tests/test_report_hygiene_full_output.py
@@ -1,0 +1,21 @@
+import sys
+import unittest
+from pathlib import Path
+
+
+BRAIN_DIR = Path(__file__).resolve().parents[1] / "docs" / "brain"
+sys.path.insert(0, str(BRAIN_DIR))
+
+import report_hygiene
+
+
+class ReportHygieneFullOutputTests(unittest.TestCase):
+    def test_rejects_chinese_full_stop_inside_details(self):
+        rendered = "# Generated report.\n<details>\nraw trace\u3002\n</details>\n"
+
+        with self.assertRaisesRegex(ValueError, "Chinese full stop"):
+            report_hygiene.validate_owned_report(rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Root cause

The 2026-07-24 generated quantitative dashboard contained `等待推演。` inside its preserved detail block even though generated Chinese reports must use English full stops.

Two conditions allowed the regression:

- `docs/brain/reason.py` still emitted eight Chinese full stops from internal generated fallback, ledger, mission, and status strings.
- `docs/brain/report_hygiene.py` validated only the text before `<details>`, so generated internal trace content bypassed the punctuation contract while the lifecycle remained green.

Historical reports and sealed archives were not edited.

## Changes

- Validate the complete generated report, including the detail block.
- Normalize all Chinese full stops emitted by `reason.py` to English full stops.
- Add one minimal regression test proving punctuation inside `<details>` is rejected.

## Reproduction evidence

The new test first failed on the unmodified implementation in Actions run `30092222097` with `AssertionError: ValueError not raised`.

After enabling full-output validation but before normalizing the generator, Actions run `30092628195` still failed, confirming the generator was the remaining source.

## Validation

Actions run `30092661990` completed successfully on the final branch head `6211d662533e55ffd57a69a05729379a2125e7ab`.

- Compiled 15 lifecycle Python files.
- Ran 29 tests during runtime validation and 29 tests again during final verification, all passing.
- Rendered two human-readable outputs with the complete punctuation validator active.
- Verified 674 entities and 641 relations with zero duplicate entities, duplicate relations, dangling relations, or invalid records.
- Lifecycle write-boundary verification passed.
- `reason.py` contains zero Chinese full-stop characters on the final branch.

The logged evolution and cortex failures are intentional negative-path tests and are followed by successful test-suite conclusions.

## Scope and conflicts

- Base main: `20b49d7fcbe295552ba1b2c86d690b256b6378e2`.
- No open PR existed before branch creation or before this PR.
- No frontend, Pages, archive, archaeology, Jules-managed directory, database, dependency, credential, permission, or workflow file was modified.
- No historical generated report was rewritten.

## Risk and rollback

Risk is limited to stricter rejection of future generated reports that contain Chinese full stops anywhere in their rendered output. This is the intended contract.

Rollback by closing this draft PR. If merged and rollback becomes necessary, revert the three branch commits without modifying generated history.